### PR TITLE
xed-searchbar.h: Add a missing include

### DIFF
--- a/xed/xed-searchbar.h
+++ b/xed/xed-searchbar.h
@@ -4,6 +4,8 @@
 
 #include <gtk/gtk.h>
 
+#include <xed/xed-window.h>
+
 G_BEGIN_DECLS
 
 /*


### PR DESCRIPTION
Fails to build without this because of the use of XedWindow