### PR TITLE
debian: Add a dependency on xapps-common

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,7 @@ Depends: iso-codes,
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
+         xapps-common,
          zenity
 XB-Python-Version: ${python:Versions}
 Description: generic text editor


### PR DESCRIPTION
We need this for some of the icons being used in the search and status bar.

Closes https://github.com/linuxmint/xed/issues/76