### PR TITLE
Fix calling set_command_line_wait()

### DIFF
--- a/xed/xed-app.c
+++ b/xed/xed-app.c
@@ -389,6 +389,15 @@ set_command_line_wait (XedApp *app,
 }
 
 static void
+set_command_line_wait_doc (XedDocument *doc,
+                           XedApp      *app)
+{
+    XedTab *tab = xed_tab_get_from_document (doc);
+
+    set_command_line_wait (app, tab);
+}
+
+static void
 open_files (GApplication            *application,
             gboolean                 new_window,
             gboolean                 new_document,
@@ -451,7 +460,7 @@ open_files (GApplication            *application,
 
         if (command_line)
         {
-            g_slist_foreach (loaded, (GFunc)set_command_line_wait, NULL);
+            g_slist_foreach (loaded, (GFunc)set_command_line_wait_doc, XED_APP (application));
         }
         g_slist_free (loaded);
     }


### PR DESCRIPTION
We were passing the wrong arguments

Based on https://github.com/GNOME/gedit/commit/2e3b5aea0e8810e6946ce4daf64fceea9a9f47a9

Fixes: https://github.com/linuxmint/xed/issues/90