### PR TITLE
Default ensure-trailing-newline to false

### DIFF
--- a/data/org.x.editor.gschema.xml.in
+++ b/data/org.x.editor.gschema.xml.in
@@ -162,7 +162,7 @@
     </key>
 
     <key name="ensure-trailing-newline" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Ensure Trailing Newline</summary>
       <description>Whether gedit will ensure that documents always end with a trailing newline.</description>
     </key>


### PR DESCRIPTION
This seems to be the default behavior for other text editors. See relevant
discussion here https://github.com/linuxmint/xed/issues/61