### PR TITLE
fix 'format not a string literal, format string not checked' error wi…

### DIFF
--- a/plugins/time/xed-time-plugin.c
+++ b/plugins/time/xed-time-plugin.c
@@ -346,12 +346,15 @@ get_time (const gchar* format)
     clock = time (NULL);
     now = localtime (&clock);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
     do
     {
         out_length += 255;
         out = g_realloc (out, out_length);
     }
     while (strftime (out, out_length, locale_format, now) == 0);
+#pragma GCC diagnostic pop
 
     g_free (locale_format);
 


### PR DESCRIPTION
…th gcc-7


```
xed-time-plugin.c: In function 'get_time':
xed-time-plugin.c:354:5: error: format not a string literal, format string not checked [-Werror=format-nonliteral]
     while (strftime (out, out_length, locale_format, now) == 0);
     ^~~~~
cc1: some warnings being treated as errors
```