### PR TITLE
Fix FSF address

### DIFF
--- a/xed/xed-app-activatable.h
+++ b/xed/xed-app-activatable.h
@@ -17,7 +17,7 @@
  *
  *  You should have received a copy of the GNU Library General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef __XED_APP_ACTIVATABLE_H__

--- a/xed/xed-view-activatable.h
+++ b/xed/xed-view-activatable.h
@@ -16,7 +16,7 @@
  *
  *  You should have received a copy of the GNU Library General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef __XED_VIEW_ACTIVATABLE_H__

--- a/xed/xed-window-activatable.h
+++ b/xed/xed-window-activatable.h
@@ -16,7 +16,7 @@
  *
  *  You should have received a copy of the GNU Library General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef __XED_WINDOW_ACTIVATABLE_H__


### PR DESCRIPTION
Fixes the error listed below

```
##### RPMs  #####
xed.armv7hl: E: explicit-lib-dependency libpeas-loader-python3(armv7hl-32)
xed.i686: E: explicit-lib-dependency libpeas-loader-python3(x86-32)
xed.x86_64: E: explicit-lib-dependency libpeas-loader-python3(x86-64)
xed-devel.armv7hl: W: no-documentation
xed-devel.armv7hl: E: incorrect-fsf-address /usr/include/xed/xed-window-activatable.h
xed-devel.armv7hl: E: incorrect-fsf-address /usr/include/xed/xed-view-activatable.h
xed-devel.armv7hl: E: incorrect-fsf-address /usr/include/xed/xed-app-activatable.h
xed-devel.i686: W: no-documentation
xed-devel.i686: E: incorrect-fsf-address /usr/include/xed/xed-window-activatable.h
xed-devel.i686: E: incorrect-fsf-address /usr/include/xed/xed-view-activatable.h
xed-devel.i686: E: incorrect-fsf-address /usr/include/xed/xed-app-activatable.h
xed-devel.x86_64: W: only-non-binary-in-usr-lib
xed-devel.x86_64: W: no-documentation
xed-devel.x86_64: E: incorrect-fsf-address /usr/include/xed/xed-window-activatable.h
xed-devel.x86_64: E: incorrect-fsf-address /usr/include/xed/xed-view-activatable.h
xed-devel.x86_64: E: incorrect-fsf-address /usr/include/xed/xed-app-activatable.h
7 packages and 0 specfiles checked; 12 errors, 4 warnings.
```