### PR TITLE
fix gtksourceprintcompositor.h includes warning

### DIFF
--- a/xed/xed-print-job.c
+++ b/xed/xed-print-job.c
@@ -34,7 +34,7 @@
 #endif
 
 #include <glib/gi18n.h>
-#include <gtksourceview/gtksourceprintcompositor.h>
+#include <gtksourceview/gtksource.h>
 
 #include "xed-print-job.h"
 #include "xed-debug.h"


### PR DESCRIPTION

```
In file included from xed-print-job.c:37:0:
/usr/include/gtksourceview-3.0/gtksourceview/gtksourceprintcompositor.h:28:6: warning: #warning "Only <gtksourceview/gtksource.h> can be included directly." [-Wcpp]
 #    warning "Only <gtksourceview/gtksource.h> can be included directly."
      ^~~~~~~
In file included from /usr/include/gtksourceview-3.0/gtksourceview/gtksourceprintcompositor.h:35:0,
                 from xed-print-job.c:37:
/usr/include/gtksourceview-3.0/gtksourceview/gtksourcetypes.h:27:6: warning: #warning "Only <gtksourceview/gtksource.h> can be included directly." [-Wcpp]
 #    warning "Only <gtksourceview/gtksource.h> can be included directly."
      ^~~~~~~
make[3]: Entering directory '/builddir/build/BUILD/xed-1.4.0/xed'
```