### PR TITLE
Text zoom: Put a limit on the min and max zoom

### DIFF
--- a/plugins/textsize/textsize/documenthelper.py
+++ b/plugins/textsize/textsize/documenthelper.py
@@ -24,6 +24,9 @@
 from .signals import Signals
 from gi.repository import Gtk, Gdk, Pango
 
+MAX_FONT_SIZE = 30
+MIN_FONT_SIZE = 5
+
 class DocumentHelper(Signals):
     def __init__(self, view):
         Signals.__init__(self)
@@ -94,6 +97,11 @@ class DocumentHelper(Signals):
         size = description.get_size() / Pango.SCALE
 
         if not bounds:
+            if size >= MAX_FONT_SIZE and amount == 1:
+                return;
+            if size <= MIN_FONT_SIZE and amount == -1:
+                return;
+
             description.set_size(max(1, (size + amount)) * Pango.SCALE)
 
             self._view.override_font(description)
@@ -116,6 +124,11 @@ class DocumentHelper(Signals):
                     newsize += tag.props.font_desc.get_size() / Pango.SCALE
 
                 newsize = round(newsize / len(tags))
+
+            if newsize >= MAX_FONT_SIZE and amount == 1:
+                return;
+            if newsize <= MIN_FONT_SIZE and amount == -1:
+                return;
 
             newsize = int(max(1, newsize))
 


### PR DESCRIPTION
It seems users can't avoid doing silly things so set a minimum and max font size
for the text zoom function. The numbers chosen here are just arbitrary values I
got from testing. If feedback warrants it, they can be easily changed.