### PR TITLE
translations: Add the textsize plugin to POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -97,6 +97,8 @@ plugins/taglist/xed-taglist-plugin-parser.c
 plugins/taglist/xed-taglist-plugin.c
 plugins/taglist/XSLT.tags.xml.in
 plugins/taglist/XUL.tags.xml.in
+plugins/textsize/textsize.plugin.desktop.in
+plugins/textsize/textsize/__init__.py
 [type: gettext/gsettings]plugins/time/org.x.editor.plugins.time.gschema.xml.in
 plugins/time/time.plugin.desktop.in
 [type: gettext/glade]plugins/time/xed-time-dialog.ui


### PR DESCRIPTION
We want the menu entries it provides to be translated but I forgot to add these
when the new plugin was added.