### PR TITLE
Add C tags to the taglist plugin

### DIFF
--- a/plugins/taglist/C.tags.xml.in
+++ b/plugins/taglist/C.tags.xml.in
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TagList xmlns="http://xed.sourceforge.net/some-location">
+<TagGroup _name="C - Tags" sort="true">
+
+  <Tag name="STDIO">
+    <Begin>#include &lt;stdio.h&gt;</Begin>
+  </Tag>
+
+  <Tag name="include">
+    <Begin>#include </Begin>
+  </Tag>
+
+  <Tag name="main">
+    <Begin>int main() {
+	</Begin>
+    <End>
+}</End>
+  </Tag>
+
+  <Tag name="Comment">
+    <Begin>/* </Begin>
+    <End> */</End>
+  </Tag>
+
+  <Tag name="Multi-Line Comment">
+    <Begin>/*
+ * </Begin>
+    <End>
+ */</End>
+  </Tag>
+
+  <Tag name="printf">
+    <Begin>printf("</Begin>
+    <End>");</End>
+  </Tag>
+
+</TagGroup>
+</TagList>


### PR DESCRIPTION
Added tags for:
 - Including stdio.h
 - `include` statements
 - The `main` function
 - Comments and multi-line comments
 - `printf` statements

See issue #187 