### PR TITLE
Fix Py*DeprecationWarning

### DIFF
--- a/plugins/textsize/textsize/__init__.py
+++ b/plugins/textsize/textsize/__init__.py
@@ -34,7 +34,7 @@ MENU_PATH = "/MenuBar/ViewMenu/ViewOps_1"
 class TextSizePlugin(GObject.Object, Xed.WindowActivatable):
     __gtype_name__ = "TextSizePlugin"
 
-    window = GObject.property(type=Xed.Window)
+    window = GObject.Property(type=Xed.Window)
 
     def __init__(self):
         GObject.Object.__init__(self)
@@ -119,7 +119,7 @@ class TextSizePlugin(GObject.Object, Xed.WindowActivatable):
         manager = self.window.get_ui_manager()
 
         # Create a new action group
-        self._action_group = Gtk.ActionGroup("XedTextSizePluginActions")
+        self._action_group = Gtk.ActionGroup(name="XedTextSizePluginActions")
         self._action_group.add_actions([("LargerTextAction", None, _("_Larger Text"),
                                          "<Ctrl>equal", None,
                                          self.on_larger_text_activate),


### PR DESCRIPTION
Fixes

```
/usr/lib64/xed/plugins/textsize/__init__.py:37: PyGIDeprecationWarning: GObject.property is deprecated; use GObject.Property instead
  window = GObject.property(type=Xed.Window)
/usr/lib64/xed/plugins/textsize/__init__.py:122: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "name" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self._action_group = Gtk.ActionGroup("XedTextSizePluginActions")
```