### PR TITLE
Fix warnings when building xed 2.0.1

### DIFF
--- a/plugins/filebrowser/xed-file-browser-plugin.c
+++ b/plugins/filebrowser/xed-file-browser-plugin.c
@@ -528,8 +528,6 @@ xed_file_browser_plugin_activate (XedWindowActivatable *activatable)
     XedPanel *panel;
     XedFileBrowserStore *store;
     gchar *data_dir;
-    GSettingsSchemaSource *schema_source;
-    GSettingsSchema *schema;
 
     priv = plugin->priv;
 

--- a/plugins/sort/xed-sort-plugin.c
+++ b/plugins/sort/xed-sort-plugin.c
@@ -165,7 +165,6 @@ buffer_sort_lines (GtkSourceBuffer    *buffer,
     gint end_line;
     gint num_lines;
     SortLine *lines;
-    gchar *last_line = NULL;
     gint i;
 
     g_return_if_fail (GTK_SOURCE_IS_BUFFER (buffer));
@@ -226,8 +225,6 @@ buffer_sort_lines (GtkSourceBuffer    *buffer,
     {
         gtk_text_buffer_insert (text_buffer, start, lines[i].line, -1);
         gtk_text_buffer_insert (text_buffer, start, "\n", -1);
-
-        last_line = lines[i].line;
     }
 
     gtk_text_buffer_end_user_action (text_buffer);

--- a/plugins/spell/xed-spell-plugin.c
+++ b/plugins/spell/xed-spell-plugin.c
@@ -492,7 +492,6 @@ update_ui (XedSpellPlugin *plugin)
     if (view != NULL)
     {
         XedTab *tab;
-        GtkTextBuffer *buffer;
 
         tab = xed_window_get_active_tab (priv->window);
         g_return_if_fail (xed_tab_get_view (tab) == view);

--- a/plugins/wordcompletion/xed-wordcompletion-plugin.c
+++ b/plugins/wordcompletion/xed-wordcompletion-plugin.c
@@ -303,7 +303,6 @@ xed_wordcompletion_view_deactivate (XedViewActivatable *activatable)
 {
     XedWordCompletionPluginPrivate *priv;
     GtkSourceCompletion *completion;
-    GtkSourceCompletionProvider *provider;
     GtkTextBuffer *buf;
 
     xed_debug (DEBUG_PLUGINS);


### PR DESCRIPTION
When building xed 2.0.1, the following warnings were printed:

```
../plugins/filebrowser/xed-file-browser-plugin.c: In function ‘xed_file_browser_plugin_activate’:
../plugins/filebrowser/xed-file-browser-plugin.c:532:22: warning: unused variable ‘schema’ [-Wunused-variable]
     GSettingsSchema *schema;
                      ^~~~~~
../plugins/filebrowser/xed-file-browser-plugin.c:531:28: warning: unused variable ‘schema_source’ [-Wunused-variable]
     GSettingsSchemaSource *schema_source;
                            ^~~~~~~~~~~~~

../plugins/sort/xed-sort-plugin.c: In function ‘buffer_sort_lines’:
../plugins/sort/xed-sort-plugin.c:168:12: warning: variable ‘last_line’ set but not used [-Wunused-but-set-variable]
     gchar *last_line = NULL;
            ^~~~~~~~~

../plugins/wordcompletion/xed-wordcompletion-plugin.c: In function ‘xed_wordcompletion_view_deactivate’:
../plugins/wordcompletion/xed-wordcompletion-plugin.c:306:34: warning: unused variable ‘provider’ [-Wunused-variable]
     GtkSourceCompletionProvider *provider;
                                  ^~~~~~~~

../plugins/spell/xed-spell-plugin.c: In function ‘update_ui’:
../plugins/spell/xed-spell-plugin.c:495:24: warning: unused variable ‘buffer’ [-Wunused-variable]
         GtkTextBuffer *buffer;
                        ^~~~~~
```

This fix removes the unused variables to fix the build warnings.