### PR TITLE
meson: require itstool command to be available

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ cc = meson.get_compiler('c')
 math = cc.find_library('m', required: false)
 
 intltool_merge = find_program('intltool-merge')
+itstool = find_program('itstool')
 
 # generate config.h
 config_h_file = configure_file(


### PR DESCRIPTION
This is needed in order to run meson's gnome.yelp() helper when installing the help data.