### PR TITLE
print preview: fix layout drawing for 1X2 and 2X1 layouts

### DIFF
--- a/xed/xed-print-preview.c
+++ b/xed/xed-print-preview.c
@@ -1124,7 +1124,7 @@ preview_draw (GtkWidget       *widget,
                 break;
             }
 
-            draw_page (cr, j * priv->tile_w, i * priv->tile_h, pg, preview);
+            draw_page (cr, i * priv->tile_w, j * priv->tile_h, pg, preview);
 
             ++pg;
         }


### PR DESCRIPTION
The indices were backwards, which was causing incorrect layout, and scrolling issues at larger zoom levels.