### PR TITLE
Print preview: remove a couple calls to gtk_adjustment_value_changed

### DIFF
--- a/xed/xed-print-preview.c
+++ b/xed/xed-print-preview.c
@@ -924,9 +924,6 @@ preview_layout_key_press (GtkWidget       *widget,
     {
         gtk_adjustment_set_value (hadj, x);
         gtk_adjustment_set_value (vadj, y);
-
-        gtk_adjustment_value_changed (hadj);
-        gtk_adjustment_value_changed (vadj);
     }
 
     return ret;


### PR DESCRIPTION
This function is no longer needed as the "value-changed" signal is automatically emitted whenever the value changes (since Gtk 3.18).