### PR TITLE
Tab width popup: only select a menu item when the menu is open

### DIFF
--- a/xed/xed-window-private.h
+++ b/xed/xed-window-private.h
@@ -57,6 +57,7 @@ struct _XedWindowPrivate
 
     GtkWidget *tab_width_button;
     GtkWidget *tab_width_menu;
+    GtkWidget *tab_width_item;
     GtkWidget *language_button;
     GtkWidget *language_popover;
     GtkWidget *show_side_pane_button;


### PR DESCRIPTION
This fixes a gdk window assertion error that occurs every time xed is opened, as well as causes the correct menu item to actually be selected as expected (it currently isn't).

The issue was caused by #241 
Fixes #272 