### PR TITLE
Prevent a warning when closing the window while print preview is open

### DIFF
--- a/xed/xed-tab.c
+++ b/xed/xed-tab.c
@@ -269,7 +269,6 @@ xed_tab_dispose (GObject *object)
 {
     XedTab *tab = XED_TAB (object);
 
-    g_clear_object (&tab->priv->editor);
     g_clear_object (&tab->priv->task_saver);
 
     clear_loading (tab);
@@ -281,6 +280,8 @@ static void
 xed_tab_finalize (GObject *object)
 {
     XedTab *tab = XED_TAB (object);
+
+    g_clear_object (&tab->priv->editor);
 
     if (tab->priv->timer != NULL)
     {


### PR DESCRIPTION
The warning was caused by the preview trying to save print settings after the settings object was cleared. Clearing the settings object in *_finalize instead of *_dispose fixes the issue.

Fixes #259 