### PR TITLE
Add settings widget to the prefs dialog for the implicit newline setting

### DIFF
--- a/xed/resources/ui/xed-preferences-dialog.ui
+++ b/xed/resources/ui/xed-preferences-dialog.ui
@@ -909,6 +909,42 @@
                         <property name="position">2</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkBox" id="box29">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkLabel" id="label23">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Ensure Trailing Newline</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="ensure_newline_switch">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="pack_type">end</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/xed/xed-preferences-dialog.c
+++ b/xed/xed-preferences-dialog.c
@@ -80,6 +80,7 @@ struct _XedPreferencesDialog
     GtkWidget *auto_save_switch;
     GtkWidget *auto_save_spin;
     GtkWidget *auto_save_revealer;
+    GtkWidget *ensure_newline_switch;
 
     /* Font */
     GtkWidget *fixed_width_font_label;
@@ -183,6 +184,7 @@ xed_preferences_dialog_class_init (XedPreferencesDialogClass *klass)
     gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, auto_save_switch);
     gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, auto_save_spin);
     gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, auto_save_revealer);
+    gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, ensure_newline_switch);
 
     /* Theme page widgets */
     gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, prefer_dark_theme_switch);
@@ -409,6 +411,12 @@ setup_save_page (XedPreferencesDialog *dlg)
                      XED_SETTINGS_AUTO_SAVE_INTERVAL,
                      dlg->auto_save_spin,
                      "value",
+                     G_SETTINGS_BIND_GET | G_SETTINGS_BIND_SET);
+
+    g_settings_bind (dlg->editor_settings,
+                     XED_SETTINGS_ENSURE_TRAILING_NEWLINE,
+                     dlg->ensure_newline_switch,
+                     "active",
                      G_SETTINGS_BIND_GET | G_SETTINGS_BIND_SET);
 
     xapp_preferences_window_add_page (XAPP_PREFERENCES_WINDOW (dlg), dlg->save_page, "save", _("Save"));


### PR DESCRIPTION
The setting was already available in the schema and implemented in xed itself, but wasn't exposed in the preferences dialog.

Addresses #195 