### PR TITLE
Added keyboard shortcut for word wrap.

### DIFF
--- a/xed/resources/ui/xed-shortcuts.ui
+++ b/xed/resources/ui/xed-shortcuts.ui
@@ -7,7 +7,7 @@
       <object class="GtkShortcutsSection">
         <property name="visible">1</property>
         <property name="section-name">shortcuts</property>
-        <property name="max-height">12</property>
+        <property name="max-height">14</property>
         <child>
           <object class="GtkShortcutsGroup">
             <property name="visible">1</property>
@@ -235,6 +235,19 @@
                 <property name="visible">1</property>
                 <property name="accelerator">&lt;ctrl&gt;P</property>
                 <property name="title" translatable="yes">Print the document</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="visible">1</property>
+            <property name="title" translatable="yes">Layout</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
+                <property name="accelerator">&lt;ctrl&gt;R</property>
+                <property name="title" translatable="yes">Toggle Word Wrap</property>
               </object>
             </child>
           </object>

--- a/xed/xed-ui.h
+++ b/xed/xed-ui.h
@@ -162,7 +162,7 @@ static const GtkToggleActionEntry xed_always_sensitive_toggle_menu_entries[] =
 	{ "ViewFullscreen", "view-fullscreen", N_("Fullscreen"), "F11",
 	  N_("Edit text in fullscreen"),
 	  G_CALLBACK (_xed_cmd_view_toggle_fullscreen_mode), FALSE },
-    { "ViewWordWrap", NULL, N_("_Word wrap"), NULL,
+    { "ViewWordWrap", NULL, N_("_Word wrap"), "<control>R",
       N_("Set word wrap for the current document"),
       G_CALLBACK (_xed_cmd_view_toggle_word_wrap), FALSE },
     { "ViewOverviewMap", NULL, N_("_Overview Map"), NULL,


### PR DESCRIPTION
This PR closes #148. Also added the keyboard shortcut to the list of shortcuts in the Help menu.

I picked "Control R" since "Control W" is already used to close a document. If "Control R" does not suffice as a proper keyboard shortcut, no worries. Let me know what keyboard shortcut would work better and I'll make the change.