### PR TITLE
Replaced Search Next mapping to F3.

### DIFF
--- a/xed/resources/ui/xed-shortcuts.ui
+++ b/xed/resources/ui/xed-shortcuts.ui
@@ -132,7 +132,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
-                <property name="accelerator">&lt;ctrl&gt;G</property>
+                <property name="accelerator">F3</property>
                 <property name="title" translatable="yes">Find the next match</property>
               </object>
             </child>

--- a/xed/xed-ui.h
+++ b/xed/xed-ui.h
@@ -115,7 +115,7 @@ static const GtkActionEntry xed_menu_entries[] =
 	/* Search menu */
 	{ "SearchFind", "edit-find-symbolic", N_("_Find"), "<control>F",
 	  N_("Search for text"), G_CALLBACK (_xed_cmd_search_find) },
-	{ "SearchFindNext", NULL, N_("Find Ne_xt"), "<control>G",
+	{ "SearchFindNext", NULL, N_("Find Ne_xt"), "F3",
 	  N_("Search forwards for the same text"), G_CALLBACK (_xed_cmd_search_find_next) },
 	{ "SearchFindPrevious", NULL, N_("Find Pre_vious"), "<shift><control>G",
 	  N_("Search backwards for the same text"), G_CALLBACK (_xed_cmd_search_find_prev) },


### PR DESCRIPTION
This PR is for feature request #227 

Removed Search Next mapping to 'Ctrl G' and replace with 'F3'. If this PR doesn't follow what was expected from the feature request, then I'll update this PR accordingly. Also if the original mapping is better suited, then I'll delete this PR. Thank.