### PR TITLE
Changed keymappings for tab navigation.

### DIFF
--- a/xed/resources/ui/xed-shortcuts.ui
+++ b/xed/resources/ui/xed-shortcuts.ui
@@ -64,14 +64,14 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
-                <property name="accelerator">&lt;ctrl&gt;&lt;Alt&gt;Page_Down</property>
+                <property name="accelerator">&lt;ctrl&gt;Tab</property>
                 <property name="title" translatable="yes">Switch to the next document</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
-                <property name="accelerator">&lt;ctrl&gt;&lt;Alt&gt;Page_Up</property>
+                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;Tab</property>
                 <property name="title" translatable="yes">Switch to the previous document</property>
               </object>
             </child>

--- a/xed/xed-ui.h
+++ b/xed/xed-ui.h
@@ -129,9 +129,9 @@ static const GtkActionEntry xed_menu_entries[] =
 	  N_("Save all open files"), G_CALLBACK (_xed_cmd_file_save_all) },
 	{ "FileCloseAll", "window-close-symbolic", N_("_Close All"), "<shift><control>W",
 	  N_("Close all open files"), G_CALLBACK (_xed_cmd_file_close_all) },
-	{ "DocumentsPreviousDocument", NULL, N_("_Previous Document"), "<alt><control>Page_Up",
+	{ "DocumentsPreviousDocument", NULL, N_("_Previous Document"), "<shift><control>Tab",
 	  N_("Activate previous document"), G_CALLBACK (_xed_cmd_documents_previous_document) },
-	{ "DocumentsNextDocument", NULL, N_("_Next Document"), "<alt><control>Page_Down",
+	{ "DocumentsNextDocument", NULL, N_("_Next Document"), "<control>Tab",
 	  N_("Activate next document"), G_CALLBACK (_xed_cmd_documents_next_document) },
 	{ "DocumentsMoveToNewWindow", NULL, N_("_Move to New Window"), NULL,
 	  N_("Move the current document to a new window"), G_CALLBACK (_xed_cmd_documents_move_to_new_window) }

--- a/xed/xed-window.c
+++ b/xed/xed-window.c
@@ -141,6 +141,19 @@ on_key_pressed (GtkWidget *widget,
         }
     }
 
+    if (event->state & GDK_CONTROL_MASK) {
+        if (event->keyval == GDK_KEY_Tab || event->keyval == GDK_KEY_KP_Tab || event->keyval == GDK_KEY_ISO_Left_Tab)
+        {
+            if (event->state & GDK_SHIFT_MASK)
+            {
+                _xed_cmd_documents_previous_document(event, window);
+            } else {
+                _xed_cmd_documents_next_document(event, window);
+            }
+            return GDK_EVENT_STOP; 
+        }
+    }
+
     return GDK_EVENT_PROPAGATE;
 }
 


### PR DESCRIPTION
This PR is for feature request #205.

I did not apply all of the changes requested in that ticket, but did implement the navigation between tabs to use `Ctrl-Tab` and `Ctrl-Shift-Tab`. This logic follows how Pluma is implementing the same concept. 

If any changes or edits need to be made, please let me know and I'll make them accordingly. Also if the keymappings need to stay with the original implementation, then I can delete this PR. 