### PR TITLE
Added logic to switch to Replace text entry on Tab event.

### DIFF
--- a/xed/xed-searchbar.c
+++ b/xed/xed-searchbar.c
@@ -645,6 +645,17 @@ on_search_text_entry_activated (GtkEntry     *widget,
 }
 
 static void
+on_search_text_entry_key_press (GtkEntry     *widget,
+                                GdkEventKey  *event,
+                                XedSearchbar *searchbar)
+{
+    if (event->keyval == GDK_KEY_Tab)
+    {
+        gtk_widget_grab_focus (searchbar->priv->replace_text_entry);
+    }
+}
+
+static void
 close_button_clicked_callback (GtkWidget    *button,
                                XedSearchbar *searchbar)
 {
@@ -720,6 +731,9 @@ xed_searchbar_init (XedSearchbar *searchbar)
     gtk_widget_show (GTK_WIDGET (searchbar));
 
     g_object_unref (content);
+
+    g_signal_connect (searchbar->priv->search_text_entry, "key-press-event",
+                      G_CALLBACK (on_search_text_entry_key_press), searchbar);
 
     g_signal_connect (searchbar->priv->search_text_entry, "changed",
                       G_CALLBACK (search_text_entry_changed), searchbar);


### PR DESCRIPTION
This PR is to fix #326. 

Added key press event for when Tab is pressed on the Search text entry to move the focus to the Replace text entry. This follows in suit on how Sublime Text handles it.

If anything on this PR needs to be changed, just let me know and I'll make the change accordingly. 