### PR TITLE
WIP - Wait option should only work with a file argument

### DIFF
--- a/data/xed.1
+++ b/data/xed.1
@@ -42,6 +42,9 @@ Output version information and exit
 \fB\-?, \-h, \-\-help\fR
 Print standard command line options.
 .TP
+\fB\-w, \-\-wait\fR
+Open files and block the xed process. Requires a file when ran.
+.TP
 \fB\-\-help\-all\fR
 Print all command line options.
 .P

--- a/xed/xed-app.c
+++ b/xed/xed-app.c
@@ -139,7 +139,7 @@ static const GOptionEntry options[] =
 
     /* Wait for closing documents */
     {
-        "wait", 'w', 0, G_OPTION_ARG_NONE, NULL,
+        "wait", 'w', 0, G_OPTION_ARG_FILENAME, NULL,
         N_("Open files and block process until files are closed"),
         NULL
     },


### PR DESCRIPTION
This fixes #284. Added logic so that the "wait" option now has to accept a filename. Updated the man page to now display info about the "wait" option.

If anything needs to be changed or updated on this PR, just let me know and I'll make the changes accordingly. 