### PR TITLE
Changed shortcut window to be non-modal.

### DIFF
--- a/xed/resources/ui/xed-shortcuts.ui
+++ b/xed/resources/ui/xed-shortcuts.ui
@@ -2,7 +2,7 @@
 <interface>
   <!-- interface-requires gtk+ 3.17 -->
   <object class="GtkShortcutsWindow" id="shortcuts-xed">
-    <property name="modal">1</property>
+    <property name="modal">0</property>
     <child>
       <object class="GtkShortcutsSection">
         <property name="visible">1</property>


### PR DESCRIPTION
This PR resolves #307. The shortcuts window can now be displayed along side xed while xed can still be used.

If anything needs to be fixed, changed, or reverted on this PR, just let me know and I'll make the change accordingly.