### PR TITLE
l10n: add missing strings for new plugin joinlines

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -78,6 +78,8 @@ plugins/filebrowser/xed-file-browser-store.c
 plugins/filebrowser/xed-file-browser-utils.c
 plugins/filebrowser/xed-file-browser-view.c
 plugins/filebrowser/xed-file-browser-widget.c
+plugins/joinlines/joinlines.plugin.desktop.in
+plugins/joinlines/joinlines/__init__.py
 plugins/modelines/modeline-parser.c
 plugins/modelines/modelines.plugin.desktop.in
 plugins/modelines/xed-modeline-plugin.c


### PR DESCRIPTION
@clefebvre You'll have to run makepot after merging this.

See https://postimg.cc/Wtss5vXC mentioned in https://github.com/linuxmint/mint20-beta/issues/25