### PR TITLE
xed-highlight-mode-dialog/selector: Clean up code style

### DIFF
--- a/xed/xed-highlight-mode-dialog.c
+++ b/xed/xed-highlight-mode-dialog.c
@@ -24,40 +24,40 @@
 
 struct _XedHighlightModeDialog
 {
-	GtkDialog parent_instance;
+    GtkDialog parent_instance;
 
-	XedHighlightModeSelector *selector;
-	gulong on_language_selected_id;
+    XedHighlightModeSelector *selector;
+    gulong on_language_selected_id;
 };
 
 G_DEFINE_TYPE (XedHighlightModeDialog, xed_highlight_mode_dialog, GTK_TYPE_DIALOG)
 
 static void
 xed_highlight_mode_dialog_response (GtkDialog *dialog,
-                                      gint       response_id)
+                                    gint       response_id)
 {
-	XedHighlightModeDialog *dlg = XED_HIGHLIGHT_MODE_DIALOG (dialog);
+    XedHighlightModeDialog *dlg = XED_HIGHLIGHT_MODE_DIALOG (dialog);
 
-	if (response_id == GTK_RESPONSE_OK)
-	{
-		g_signal_handler_block (dlg->selector, dlg->on_language_selected_id);
-		xed_highlight_mode_selector_activate_selected_language (dlg->selector);
-		g_signal_handler_unblock (dlg->selector, dlg->on_language_selected_id);
-	}
+    if (response_id == GTK_RESPONSE_OK)
+    {
+        g_signal_handler_block (dlg->selector, dlg->on_language_selected_id);
+        xed_highlight_mode_selector_activate_selected_language (dlg->selector);
+        g_signal_handler_unblock (dlg->selector, dlg->on_language_selected_id);
+    }
 
-	gtk_widget_destroy (GTK_WIDGET (dialog));
+    gtk_widget_destroy (GTK_WIDGET (dialog));
 }
 
 static void
 on_language_selected (XedHighlightModeSelector *sel,
-                      GtkSourceLanguage          *language,
+                      GtkSourceLanguage        *language,
                       XedHighlightModeDialog   *dlg)
 {
-	g_signal_handler_block (dlg->selector, dlg->on_language_selected_id);
-	xed_highlight_mode_selector_activate_selected_language (dlg->selector);
-	g_signal_handler_unblock (dlg->selector, dlg->on_language_selected_id);
+    g_signal_handler_block (dlg->selector, dlg->on_language_selected_id);
+    xed_highlight_mode_selector_activate_selected_language (dlg->selector);
+    g_signal_handler_unblock (dlg->selector, dlg->on_language_selected_id);
 
-	gtk_widget_destroy (GTK_WIDGET (dlg));
+    gtk_widget_destroy (GTK_WIDGET (dlg));
 }
 
 static void
@@ -70,25 +70,25 @@ on_dialog_cancelled (XedHighlightModeSelector *sel,
 static void
 xed_highlight_mode_dialog_class_init (XedHighlightModeDialogClass *klass)
 {
-	GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
-	GtkDialogClass *dialog_class = GTK_DIALOG_CLASS (klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+    GtkDialogClass *dialog_class = GTK_DIALOG_CLASS (klass);
 
-	dialog_class->response = xed_highlight_mode_dialog_response;
+    dialog_class->response = xed_highlight_mode_dialog_response;
 
-	/* Bind class to template */
-	gtk_widget_class_set_template_from_resource (widget_class,
-	                                             "/org/x/editor/ui/xed-highlight-mode-dialog.ui");
-	gtk_widget_class_bind_template_child (widget_class, XedHighlightModeDialog, selector);
+    /* Bind class to template */
+    gtk_widget_class_set_template_from_resource (widget_class,
+                                                 "/org/x/editor/ui/xed-highlight-mode-dialog.ui");
+    gtk_widget_class_bind_template_child (widget_class, XedHighlightModeDialog, selector);
 }
 
 static void
 xed_highlight_mode_dialog_init (XedHighlightModeDialog *dlg)
 {
-	gtk_widget_init_template (GTK_WIDGET (dlg));
-	gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
+    gtk_widget_init_template (GTK_WIDGET (dlg));
+    gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
 
-	dlg->on_language_selected_id = g_signal_connect (dlg->selector, "language-selected",
-	                                                 G_CALLBACK (on_language_selected), dlg);
+    dlg->on_language_selected_id = g_signal_connect (dlg->selector, "language-selected",
+                                                     G_CALLBACK (on_language_selected), dlg);
 
     g_signal_connect (dlg->selector, "cancelled",
                       G_CALLBACK (on_dialog_cancelled), dlg);
@@ -97,17 +97,15 @@ xed_highlight_mode_dialog_init (XedHighlightModeDialog *dlg)
 GtkWidget *
 xed_highlight_mode_dialog_new (GtkWindow *parent)
 {
-	return GTK_WIDGET (g_object_new (XED_TYPE_HIGHLIGHT_MODE_DIALOG,
-	                                 "transient-for", parent,
-	                                 NULL));
+    return GTK_WIDGET (g_object_new (XED_TYPE_HIGHLIGHT_MODE_DIALOG,
+                                     "transient-for", parent,
+                                     NULL));
 }
 
 XedHighlightModeSelector *
 xed_highlight_mode_dialog_get_selector (XedHighlightModeDialog *dlg)
 {
-	g_return_val_if_fail (XED_IS_HIGHLIGHT_MODE_DIALOG (dlg), NULL);
+    g_return_val_if_fail (XED_IS_HIGHLIGHT_MODE_DIALOG (dlg), NULL);
 
-	return dlg->selector;
+    return dlg->selector;
 }
-
-/* ex:set ts=8 noet: */

--- a/xed/xed-highlight-mode-selector.c
+++ b/xed/xed-highlight-mode-selector.c
@@ -26,28 +26,28 @@
 
 enum
 {
-	COLUMN_NAME,
-	COLUMN_LANG,
-	N_COLUMNS
+    COLUMN_NAME,
+    COLUMN_LANG,
+    N_COLUMNS
 };
 
 struct _XedHighlightModeSelector
 {
-	GtkGrid parent_instance;
+    GtkGrid parent_instance;
 
-	GtkWidget *treeview;
-	GtkWidget *entry;
-	GtkListStore *liststore;
-	GtkTreeModelFilter *treemodelfilter;
-	GtkTreeSelection *treeview_selection;
+    GtkWidget *treeview;
+    GtkWidget *entry;
+    GtkListStore *liststore;
+    GtkTreeModelFilter *treemodelfilter;
+    GtkTreeSelection *treeview_selection;
 };
 
 /* Signals */
 enum
 {
-	LANGUAGE_SELECTED,
+    LANGUAGE_SELECTED,
     CANCELLED,
-	LAST_SIGNAL
+    LAST_SIGNAL
 };
 
 static guint signals[LAST_SIGNAL] = { 0 };
@@ -56,24 +56,24 @@ G_DEFINE_TYPE (XedHighlightModeSelector, xed_highlight_mode_selector, GTK_TYPE_G
 
 static void
 xed_highlight_mode_selector_language_selected (XedHighlightModeSelector *widget,
-                                                 GtkSourceLanguage          *language)
+                                               GtkSourceLanguage          *language)
 {
 }
 
 static void
 xed_highlight_mode_selector_class_init (XedHighlightModeSelectorClass *klass)
 {
-	GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
-	signals[LANGUAGE_SELECTED] =
-		g_signal_new_class_handler ("language-selected",
-		                            G_TYPE_FROM_CLASS (klass),
-		                            G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
-		                            G_CALLBACK (xed_highlight_mode_selector_language_selected),
-		                            NULL, NULL, NULL,
-		                            G_TYPE_NONE,
-		                            1,
-		                            GTK_SOURCE_TYPE_LANGUAGE);
+    signals[LANGUAGE_SELECTED] =
+        g_signal_new_class_handler ("language-selected",
+                                    G_TYPE_FROM_CLASS (klass),
+                                    G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+                                    G_CALLBACK (xed_highlight_mode_selector_language_selected),
+                                    NULL, NULL, NULL,
+                                    G_TYPE_NONE,
+                                    1,
+                                    GTK_SOURCE_TYPE_LANGUAGE);
 
     signals[CANCELLED] =
         g_signal_new_class_handler ("cancelled",
@@ -82,162 +82,162 @@ xed_highlight_mode_selector_class_init (XedHighlightModeSelectorClass *klass)
                                     NULL, NULL, NULL, NULL,
                                     G_TYPE_NONE, 0);
 
-	/* Bind class to template */
-	gtk_widget_class_set_template_from_resource (widget_class,
-	                                             "/org/x/editor/ui/xed-highlight-mode-selector.ui");
-	gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, treeview);
-	gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, entry);
-	gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, liststore);
-	gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, treemodelfilter);
-	gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, treeview_selection);
+    /* Bind class to template */
+    gtk_widget_class_set_template_from_resource (widget_class,
+                                                 "/org/x/editor/ui/xed-highlight-mode-selector.ui");
+    gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, treeview);
+    gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, entry);
+    gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, liststore);
+    gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, treemodelfilter);
+    gtk_widget_class_bind_template_child (widget_class, XedHighlightModeSelector, treeview_selection);
 }
 
 static gboolean
-visible_func (GtkTreeModel               *model,
-              GtkTreeIter                *iter,
+visible_func (GtkTreeModel             *model,
+              GtkTreeIter              *iter,
               XedHighlightModeSelector *selector)
 {
-	const gchar *entry_text;
-	gchar *name;
-	gchar *name_normalized;
-	gchar *name_casefolded;
-	gchar *text_normalized;
-	gchar *text_casefolded;
-	gboolean visible = FALSE;
+    const gchar *entry_text;
+    gchar *name;
+    gchar *name_normalized;
+    gchar *name_casefolded;
+    gchar *text_normalized;
+    gchar *text_casefolded;
+    gboolean visible = FALSE;
 
-	entry_text = gtk_entry_get_text (GTK_ENTRY (selector->entry));
+    entry_text = gtk_entry_get_text (GTK_ENTRY (selector->entry));
 
-	if (*entry_text == '\0')
-	{
-		return TRUE;
-	}
+    if (*entry_text == '\0')
+    {
+        return TRUE;
+    }
 
-	gtk_tree_model_get (model, iter, COLUMN_NAME, &name, -1);
+    gtk_tree_model_get (model, iter, COLUMN_NAME, &name, -1);
 
-	name_normalized = g_utf8_normalize (name, -1, G_NORMALIZE_ALL);
-	g_free (name);
+    name_normalized = g_utf8_normalize (name, -1, G_NORMALIZE_ALL);
+    g_free (name);
 
-	name_casefolded = g_utf8_casefold (name_normalized, -1);
-	g_free (name_normalized);
+    name_casefolded = g_utf8_casefold (name_normalized, -1);
+    g_free (name_normalized);
 
-	text_normalized = g_utf8_normalize (entry_text, -1, G_NORMALIZE_ALL);
-	text_casefolded = g_utf8_casefold (text_normalized, -1);
-	g_free (text_normalized);
+    text_normalized = g_utf8_normalize (entry_text, -1, G_NORMALIZE_ALL);
+    text_casefolded = g_utf8_casefold (text_normalized, -1);
+    g_free (text_normalized);
 
-	if (strstr (name_casefolded, text_casefolded) != NULL)
-	{
-		visible = TRUE;
-	}
+    if (strstr (name_casefolded, text_casefolded) != NULL)
+    {
+        visible = TRUE;
+    }
 
-	g_free (name_casefolded);
-	g_free (text_casefolded);
+    g_free (name_casefolded);
+    g_free (text_casefolded);
 
-	return visible;
+    return visible;
 }
 
 static void
-on_entry_activate (GtkEntry                   *entry,
+on_entry_activate (GtkEntry                 *entry,
                    XedHighlightModeSelector *selector)
 {
-	xed_highlight_mode_selector_activate_selected_language (selector);
+    xed_highlight_mode_selector_activate_selected_language (selector);
 }
 
 static void
-on_entry_changed (GtkEntry                   *entry,
+on_entry_changed (GtkEntry                 *entry,
                   XedHighlightModeSelector *selector)
 {
-	GtkTreeIter iter;
+    GtkTreeIter iter;
 
-	gtk_tree_model_filter_refilter (selector->treemodelfilter);
+    gtk_tree_model_filter_refilter (selector->treemodelfilter);
 
-	if (gtk_tree_model_get_iter_first (GTK_TREE_MODEL (selector->treemodelfilter), &iter))
-	{
-		gtk_tree_selection_select_iter (selector->treeview_selection, &iter);
-	}
+    if (gtk_tree_model_get_iter_first (GTK_TREE_MODEL (selector->treemodelfilter), &iter))
+    {
+        gtk_tree_selection_select_iter (selector->treeview_selection, &iter);
+    }
 }
 
 static gboolean
 move_selection (XedHighlightModeSelector *selector,
                 gint                      howmany)
 {
-	GtkTreeIter iter;
-	GtkTreePath *path;
-	gint *indices;
-	gint ret = FALSE;
+    GtkTreeIter iter;
+    GtkTreePath *path;
+    gint *indices;
+    gint ret = FALSE;
 
-	if (!gtk_tree_selection_get_selected (selector->treeview_selection, NULL, &iter) &&
-	    !gtk_tree_model_get_iter_first (GTK_TREE_MODEL (selector->treemodelfilter), &iter))
-	{
-		return FALSE;
-	}
+    if (!gtk_tree_selection_get_selected (selector->treeview_selection, NULL, &iter) &&
+        !gtk_tree_model_get_iter_first (GTK_TREE_MODEL (selector->treemodelfilter), &iter))
+    {
+        return FALSE;
+    }
 
-	path = gtk_tree_model_get_path (GTK_TREE_MODEL (selector->treemodelfilter), &iter);
-	indices = gtk_tree_path_get_indices (path);
+    path = gtk_tree_model_get_path (GTK_TREE_MODEL (selector->treemodelfilter), &iter);
+    indices = gtk_tree_path_get_indices (path);
 
-	if (indices)
-	{
-		gint num;
-		gint idx;
-		GtkTreePath *new_path;
+    if (indices)
+    {
+        gint num;
+        gint idx;
+        GtkTreePath *new_path;
 
-		idx = indices[0];
-		num = gtk_tree_model_iter_n_children (GTK_TREE_MODEL (selector->treemodelfilter), NULL);
+        idx = indices[0];
+        num = gtk_tree_model_iter_n_children (GTK_TREE_MODEL (selector->treemodelfilter), NULL);
 
-		if ((idx + howmany) < 0)
-		{
-			idx = 0;
-		}
-		else if ((idx + howmany) >= num)
-		{
-			idx = num - 1;
-		}
-		else
-		{
-			idx = idx + howmany;
-		}
+        if ((idx + howmany) < 0)
+        {
+            idx = 0;
+        }
+        else if ((idx + howmany) >= num)
+        {
+            idx = num - 1;
+        }
+        else
+        {
+            idx = idx + howmany;
+        }
 
-		new_path = gtk_tree_path_new_from_indices (idx, -1);
-		gtk_tree_selection_select_path (selector->treeview_selection, new_path);
-		gtk_tree_view_scroll_to_cell (GTK_TREE_VIEW (selector->treeview),
-		                              new_path, NULL, TRUE, 0.5, 0);
-		gtk_tree_path_free (new_path);
+        new_path = gtk_tree_path_new_from_indices (idx, -1);
+        gtk_tree_selection_select_path (selector->treeview_selection, new_path);
+        gtk_tree_view_scroll_to_cell (GTK_TREE_VIEW (selector->treeview),
+                                      new_path, NULL, TRUE, 0.5, 0);
+        gtk_tree_path_free (new_path);
 
-		ret = TRUE;
-	}
+        ret = TRUE;
+    }
 
-	gtk_tree_path_free (path);
+    gtk_tree_path_free (path);
 
-	return ret;
+    return ret;
 }
 
 static gboolean
-on_entry_key_press_event (GtkWidget                  *entry,
-                          GdkEventKey                *event,
+on_entry_key_press_event (GtkWidget                *entry,
+                          GdkEventKey              *event,
                           XedHighlightModeSelector *selector)
 {
-	if (event->keyval == GDK_KEY_Down)
-	{
-		return move_selection (selector, 1);
-	}
-	else if (event->keyval == GDK_KEY_Up)
-	{
-		return move_selection (selector, -1);
-	}
-	else if (event->keyval == GDK_KEY_Page_Down)
-	{
-		return move_selection (selector, 5);
-	}
-	else if (event->keyval == GDK_KEY_Page_Up)
-	{
-		return move_selection (selector, -5);
-	}
+    if (event->keyval == GDK_KEY_Down)
+    {
+        return move_selection (selector, 1);
+    }
+    else if (event->keyval == GDK_KEY_Up)
+    {
+        return move_selection (selector, -1);
+    }
+    else if (event->keyval == GDK_KEY_Page_Down)
+    {
+        return move_selection (selector, 5);
+    }
+    else if (event->keyval == GDK_KEY_Page_Up)
+    {
+        return move_selection (selector, -5);
+    }
     else if (event->keyval == GDK_KEY_Escape)
     {
         g_signal_emit (G_OBJECT (selector), signals[CANCELLED], 0);
         return FALSE;
     }
 
-	return FALSE;
+    return FALSE;
 }
 
 static void
@@ -255,152 +255,150 @@ on_entry_realized (GtkWidget                *entry,
 }
 
 static void
-on_row_activated (GtkTreeView                *tree_view,
-                  GtkTreePath                *path,
-                  GtkTreeViewColumn          *column,
+on_row_activated (GtkTreeView              *tree_view,
+                  GtkTreePath              *path,
+                  GtkTreeViewColumn        *column,
                   XedHighlightModeSelector *selector)
 {
-	xed_highlight_mode_selector_activate_selected_language (selector);
+    xed_highlight_mode_selector_activate_selected_language (selector);
 }
 
 static void
 xed_highlight_mode_selector_init (XedHighlightModeSelector *selector)
 {
-	GtkSourceLanguageManager *lm;
-	const gchar * const *ids;
-	gint i;
-	GtkTreeIter iter;
+    GtkSourceLanguageManager *lm;
+    const gchar * const *ids;
+    gint i;
+    GtkTreeIter iter;
 
-	selector = xed_highlight_mode_selector_get_instance_private (selector);
+    selector = xed_highlight_mode_selector_get_instance_private (selector);
 
-	gtk_widget_init_template (GTK_WIDGET (selector));
+    gtk_widget_init_template (GTK_WIDGET (selector));
 
-	gtk_tree_model_filter_set_visible_func (selector->treemodelfilter,
-	                                        (GtkTreeModelFilterVisibleFunc)visible_func,
-	                                        selector,
-	                                        NULL);
+    gtk_tree_model_filter_set_visible_func (selector->treemodelfilter,
+                                            (GtkTreeModelFilterVisibleFunc)visible_func,
+                                            selector,
+                                            NULL);
 
-	g_signal_connect (selector->entry, "activate",
-	                  G_CALLBACK (on_entry_activate), selector);
-	g_signal_connect (selector->entry, "changed",
-	                  G_CALLBACK (on_entry_changed), selector);
-	g_signal_connect (selector->entry, "key-press-event",
-	                  G_CALLBACK (on_entry_key_press_event), selector);
+    g_signal_connect (selector->entry, "activate",
+                      G_CALLBACK (on_entry_activate), selector);
+    g_signal_connect (selector->entry, "changed",
+                      G_CALLBACK (on_entry_changed), selector);
+    g_signal_connect (selector->entry, "key-press-event",
+                      G_CALLBACK (on_entry_key_press_event), selector);
     g_signal_connect (selector->entry, "realize",
                       G_CALLBACK (on_entry_realized), selector);
-	g_signal_connect (selector->treeview, "row-activated",
-	                  G_CALLBACK (on_row_activated), selector);
+    g_signal_connect (selector->treeview, "row-activated",
+                      G_CALLBACK (on_row_activated), selector);
 
-	/* Populate tree model */
-	gtk_list_store_append (selector->liststore, &iter);
-	gtk_list_store_set (selector->liststore, &iter,
-	                    COLUMN_NAME, _("Plain Text"),
-	                    COLUMN_LANG, NULL,
-	                    -1);
+    /* Populate tree model */
+    gtk_list_store_append (selector->liststore, &iter);
+    gtk_list_store_set (selector->liststore, &iter,
+                        COLUMN_NAME, _("Plain Text"),
+                        COLUMN_LANG, NULL,
+                        -1);
 
-	lm = gtk_source_language_manager_get_default ();
-	ids = gtk_source_language_manager_get_language_ids (lm);
+    lm = gtk_source_language_manager_get_default ();
+    ids = gtk_source_language_manager_get_language_ids (lm);
 
-	for (i = 0; ids[i] != NULL; i++)
-	{
-		GtkSourceLanguage *lang;
+    for (i = 0; ids[i] != NULL; i++)
+    {
+        GtkSourceLanguage *lang;
 
-		lang = gtk_source_language_manager_get_language (lm, ids[i]);
+        lang = gtk_source_language_manager_get_language (lm, ids[i]);
 
-		if (!gtk_source_language_get_hidden (lang))
-		{
-			gtk_list_store_append (selector->liststore, &iter);
-			gtk_list_store_set (selector->liststore, &iter,
-			                    COLUMN_NAME, gtk_source_language_get_name (lang),
-			                    COLUMN_LANG, lang,
-			                    -1);
-		}
-	}
+        if (!gtk_source_language_get_hidden (lang))
+        {
+            gtk_list_store_append (selector->liststore, &iter);
+            gtk_list_store_set (selector->liststore, &iter,
+                                COLUMN_NAME, gtk_source_language_get_name (lang),
+                                COLUMN_LANG, lang,
+                                -1);
+        }
+    }
 
-	/* select first item */
-	if (gtk_tree_model_get_iter_first (GTK_TREE_MODEL (selector->treemodelfilter), &iter))
-	{
-		gtk_tree_selection_select_iter (selector->treeview_selection, &iter);
-	}
+    /* select first item */
+    if (gtk_tree_model_get_iter_first (GTK_TREE_MODEL (selector->treemodelfilter), &iter))
+    {
+        gtk_tree_selection_select_iter (selector->treeview_selection, &iter);
+    }
 }
 
 XedHighlightModeSelector *
 xed_highlight_mode_selector_new ()
 {
-	return g_object_new (XED_TYPE_HIGHLIGHT_MODE_SELECTOR, NULL);
+    return g_object_new (XED_TYPE_HIGHLIGHT_MODE_SELECTOR, NULL);
 }
 
 void
 xed_highlight_mode_selector_select_language (XedHighlightModeSelector *selector,
                                              GtkSourceLanguage        *language)
 {
-	GtkTreeIter iter;
+    GtkTreeIter iter;
 
-	g_return_if_fail (XED_IS_HIGHLIGHT_MODE_SELECTOR (selector));
+    g_return_if_fail (XED_IS_HIGHLIGHT_MODE_SELECTOR (selector));
 
-	if (language == NULL)
-	{
-		return;
-	}
+    if (language == NULL)
+    {
+        return;
+    }
 
-	if (gtk_tree_model_get_iter_first (GTK_TREE_MODEL (selector->treemodelfilter), &iter))
-	{
-		do
-		{
-			GtkSourceLanguage *lang;
+    if (gtk_tree_model_get_iter_first (GTK_TREE_MODEL (selector->treemodelfilter), &iter))
+    {
+        do
+        {
+            GtkSourceLanguage *lang;
 
-			gtk_tree_model_get (GTK_TREE_MODEL (selector->treemodelfilter),
-			                    &iter,
-			                    COLUMN_LANG, &lang,
-			                    -1);
+            gtk_tree_model_get (GTK_TREE_MODEL (selector->treemodelfilter),
+                                &iter,
+                                COLUMN_LANG, &lang,
+                                -1);
 
-			if (lang != NULL)
-			{
-				gboolean equal = (lang == language);
+            if (lang != NULL)
+            {
+                gboolean equal = (lang == language);
 
-				g_object_unref (lang);
+                g_object_unref (lang);
 
-				if (equal)
-				{
-					GtkTreePath *path;
+                if (equal)
+                {
+                    GtkTreePath *path;
 
-					path = gtk_tree_model_get_path (GTK_TREE_MODEL (selector->treemodelfilter), &iter);
+                    path = gtk_tree_model_get_path (GTK_TREE_MODEL (selector->treemodelfilter), &iter);
 
-					gtk_tree_selection_select_iter (selector->treeview_selection, &iter);
-					gtk_tree_view_scroll_to_cell (GTK_TREE_VIEW (selector->treeview),
-					                              path, NULL, TRUE, 0.5, 0);
-					gtk_tree_path_free (path);
-					break;
-				}
-			}
-		}
-		while (gtk_tree_model_iter_next (GTK_TREE_MODEL (selector->treemodelfilter), &iter));
-	}
+                    gtk_tree_selection_select_iter (selector->treeview_selection, &iter);
+                    gtk_tree_view_scroll_to_cell (GTK_TREE_VIEW (selector->treeview),
+                                                  path, NULL, TRUE, 0.5, 0);
+                    gtk_tree_path_free (path);
+                    break;
+                }
+            }
+        }
+        while (gtk_tree_model_iter_next (GTK_TREE_MODEL (selector->treemodelfilter), &iter));
+    }
 }
 
 void
 xed_highlight_mode_selector_activate_selected_language (XedHighlightModeSelector *selector)
 {
-	GtkSourceLanguage *lang;
-	GtkTreeIter iter;
+    GtkSourceLanguage *lang;
+    GtkTreeIter iter;
 
-	g_return_if_fail (XED_IS_HIGHLIGHT_MODE_SELECTOR (selector));
+    g_return_if_fail (XED_IS_HIGHLIGHT_MODE_SELECTOR (selector));
 
-	if (!gtk_tree_selection_get_selected (selector->treeview_selection, NULL, &iter))
-	{
-		return;
-	}
+    if (!gtk_tree_selection_get_selected (selector->treeview_selection, NULL, &iter))
+    {
+        return;
+    }
 
-	gtk_tree_model_get (GTK_TREE_MODEL (selector->treemodelfilter), &iter,
-	                    COLUMN_LANG, &lang,
-	                    -1);
+    gtk_tree_model_get (GTK_TREE_MODEL (selector->treemodelfilter), &iter,
+                        COLUMN_LANG, &lang,
+                        -1);
 
-	g_signal_emit (G_OBJECT (selector), signals[LANGUAGE_SELECTED], 0, lang);
+    g_signal_emit (G_OBJECT (selector), signals[LANGUAGE_SELECTED], 0, lang);
 
-	if (lang != NULL)
-	{
-		g_object_unref (lang);
-	}
+    if (lang != NULL)
+    {
+        g_object_unref (lang);
+    }
 }
-
-/* ex:set ts=8 noet: */


### PR DESCRIPTION
Fix a few indentation errors and convert tabs to spaces.