### PR TITLE
Fix crashes when no documents (tabs) are open

### DIFF
--- a/xed/xed-commands-view.c
+++ b/xed/xed-commands-view.c
@@ -155,6 +155,12 @@ _xed_cmd_view_toggle_overview_map (GtkAction *action,
     xed_debug (DEBUG_COMMANDS);
 
     tab = xed_window_get_active_tab (window);
+
+    if (tab == NULL)
+    {
+        return;
+    }
+
     frame = XED_VIEW_FRAME (_xed_tab_get_view_frame (tab));
     map_frame = xed_view_frame_get_map_frame (frame);
     visible = gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action));

--- a/xed/xed-tab.c
+++ b/xed/xed-tab.c
@@ -3001,5 +3001,7 @@ xed_tab_set_info_bar (XedTab    *tab,
 GtkWidget *
 _xed_tab_get_view_frame (XedTab *tab)
 {
+    g_return_val_if_fail (XED_IS_TAB (tab), NULL);
+
     return GTK_WIDGET (tab->priv->frame);
 }

--- a/xed/xed-window.c
+++ b/xed/xed-window.c
@@ -115,7 +115,7 @@ save_panes_state (XedWindow *window)
     g_settings_apply (window->priv->window_settings);
 }
 
-static gint
+static gboolean
 on_key_pressed (GtkWidget *widget,
                 GdkEventKey *event,
                 XedWindow *window)
@@ -126,17 +126,19 @@ on_key_pressed (GtkWidget *widget,
         XedViewFrame *frame;
 
         tab = xed_window_get_active_tab (window);
-        frame = XED_VIEW_FRAME (_xed_tab_get_view_frame (tab));
 
-        if (xed_view_frame_get_search_popup_visible (frame))
+        if (tab != NULL)
         {
-            return GDK_EVENT_PROPAGATE;
+            frame = XED_VIEW_FRAME (_xed_tab_get_view_frame (tab));
+
+            if (xed_view_frame_get_search_popup_visible (frame))
+            {
+                return GDK_EVENT_PROPAGATE;
+            }
         }
-        else
-        {
-            xed_searchbar_hide (XED_SEARCHBAR (window->priv->searchbar));
-            return GDK_EVENT_STOP;
-        }
+
+        xed_searchbar_hide (XED_SEARCHBAR (window->priv->searchbar));
+        return GDK_EVENT_STOP;
     }
 
     return GDK_EVENT_PROPAGATE;


### PR DESCRIPTION
Two crashes are possible:

1. Fixes #450 (toggle overview map without any open tabs/docs)
2. Pressing ESC (e.g. to close searchbar) without any tabs open