### PR TITLE
Uses strtol instead of atoi so that we can properly handle over/underflow.

### DIFF
--- a/xed/xed-utils.c
+++ b/xed/xed-utils.c
@@ -61,6 +61,13 @@ xed_gdk_color_to_string (GdkColor color)
     return g_strdup_printf ("#%04x%04x%04x", color.red, color.green, color.blue);
 }
 
+gint
+xed_string_to_clamped_gint (const gchar *text)
+{
+    long int long_line = strtol (text, NULL, 10);
+    return MAX(MIN(long_line, INT_MAX), INT_MIN);
+}
+
 /*
  * n: len of the string in bytes
  */

--- a/xed/xed-utils.c
+++ b/xed/xed-utils.c
@@ -65,7 +65,7 @@ gint
 xed_string_to_clamped_gint (const gchar *text)
 {
     long int long_line = strtol (text, NULL, 10);
-    return MAX(MIN(long_line, INT_MAX), INT_MIN);
+    return CLAMP (long_line, INT_MIN, INT_MAX);
 }
 
 /*

--- a/xed/xed-utils.h
+++ b/xed/xed-utils.h
@@ -50,6 +50,8 @@ enum { XED_ALL_WORKSPACES = 0xffffffff };
 
 gchar *xed_gdk_color_to_string (GdkColor color);
 
+gint xed_string_to_clamped_gint (const gchar *text);
+
 gchar *xed_utils_escape_underscores (const gchar *text,
                                      gssize       length);
 

--- a/xed/xed-view-frame.c
+++ b/xed/xed-view-frame.c
@@ -315,7 +315,7 @@ search_init (GtkWidget      *entry,
 
             if (*(text + 1) != '\0')
             {
-                offset_line = MAX (atoi (text + 1), 0);
+                offset_line = MAX (xed_string_to_clamped_gint (text + 1), 0);
             }
 
             line = MAX (cur_line - offset_line, 0);
@@ -326,19 +326,19 @@ search_init (GtkWidget      *entry,
 
             if (*(text + 1) != '\0')
             {
-                offset_line = MAX (atoi (text + 1), 0);
+                offset_line = MAX (xed_string_to_clamped_gint (text + 1), 0);
             }
 
             line = cur_line + offset_line;
         }
         else
         {
-            line = MAX (atoi (text) - 1, 0);
+            line = MAX (xed_string_to_clamped_gint (text) - 1, 0);
         }
 
         if (split_text[1] != NULL)
         {
-            line_offset = atoi (split_text[1]);
+            line_offset = xed_string_to_clamped_gint (split_text[1]);
         }
 
         g_strfreev (split_text);


### PR DESCRIPTION
This now handles overflow and underflow correctly, by parsing the string
and then clamping the value between INT_MIN and INT_MAX. `atoi` was
giving us garbage values when the buffer overflowed.

Fixes #408