### PR TITLE
meson.build: keep temporary files between builds

### DIFF
--- a/plugins/taglist/meson.build
+++ b/plugins/taglist/meson.build
@@ -56,7 +56,7 @@ foreach tagtype : taglist_in_files
         '@0@gztags'.format(tagtype.format('')),
         input: taglist_xml,
         output: tagtype.format('.gz'),
-        command: ['gzip', '-9', '-n', '-f', '@INPUT@'],
+        command: ['gzip', '-9', '-n', '--keep', '-f', '@INPUT@'],
         install: true,
         install_dir: join_paths(pluginsdatadir, 'taglist')
     )


### PR DESCRIPTION
Avoids unnecessary rebuilds of the taglist plugin's .tags.gz files