### PR TITLE
Completed fr_CA.po file, for French (Canada) translations.

### DIFF
--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -1,22 +1,25 @@
 # French (Canada) translation for linuxmint
 # Copyright (c) 2016 Rosetta Contributors and Canonical Ltd 2016
-# This file is distributed under the same license as the linuxmint package.
+# This file is distributed under the same license as the xed package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
 #
+# Translators:
+# Martin Bertrand, 2021
 msgid ""
 msgstr ""
-"Project-Id-Version: linuxmint\n"
-"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
-"POT-Creation-Date: 2021-10-11 13:43+0100\n"
-"PO-Revision-Date: 2021-12-06 14:36+0000\n"
-"Last-Translator: guwrt <guwrt77@gmail.com>\n"
+"Project-Id-Version: MATE Desktop Environment\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-06-01 12:55+0100\n"
+"PO-Revision-Date: 2021-12-02 23:59+0000\n"
+"Last-Translator: Martin Bertrand <xed@mbertrand.ca>\n"
 "Language-Team: French (Canada) <fr_CA@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Launchpad-Export-Date: 2021-12-06 15:03+0000\n"
-"X-Generator: Launchpad (build f92b6e0bb2624f8a9125e3f45b7621c6e230c5ff)\n"
+"X-Launchpad-Export-Date: 2021-06-25 10:39+0000\n"
+"X-Generator: Launchpad (build 40cc6dba4163ba9ca785b26ad91f43c87d70ba4d)\n"
+"Language: fr_CA\n"
 
 #: ../data/xed.appdata.xml.in.h:1
 msgid "A Text Editor"
@@ -52,23 +55,23 @@ msgstr "Éditer des fichiers texte"
 
 #: ../xed/xed-app.c:100
 msgid "Show the application's version"
-msgstr "Affiche la version de l'application"
+msgstr "Afficher la version de l'application"
 
 #: ../xed/xed-app.c:106
 msgid "Display list of possible values for the encoding option"
-msgstr "Affiche la liste des valeurs possibles pour l’option de codage"
+msgstr "Afficher la liste des valeurs possibles pour l'option de codage"
 
 #: ../xed/xed-app.c:113
 msgid ""
 "Set the character encoding to be used to open the files listed on the "
 "command line"
 msgstr ""
-"Défini le codage des caractères à utiliser pour ouvrir les fichiers listés "
+"Définir le codage de caractères à utiliser pour ouvrir les fichiers listés "
 "dans la ligne de commande"
 
 #: ../xed/xed-app.c:114
 msgid "ENCODING"
-msgstr "ENCODAGE"
+msgstr "CODAGE"
 
 #: ../xed/xed-app.c:120
 msgid "Create a new top-level window in an existing instance of xed"
@@ -85,7 +88,7 @@ msgstr "Définir la taille et la position de la fenêtre (LARGEURxHAUTEUR+X+Y)"
 
 #: ../xed/xed-app.c:135
 msgid "GEOMETRY"
-msgstr "GÉOMÉTRIE"
+msgstr "GEOMETRY"
 
 #: ../xed/xed-app.c:141
 msgid "Open files and block process until files are closed"
@@ -107,7 +110,7 @@ msgstr "%s : codage non valide."
 
 #: ../xed/xed-app.c:1266
 msgid "There was an error displaying the help."
-msgstr "Une erreur s’est produite lors de l’affichage de l’aide."
+msgstr "Une erreur s'est produite lors de l'affichage de l'aide."
 
 #: ../xed/xed-close-confirmation-dialog.c:129
 msgid "Log Out _without Saving"
@@ -115,11 +118,11 @@ msgstr "Se déconnecter _sans enregistrer"
 
 #: ../xed/xed-close-confirmation-dialog.c:130
 msgid "_Cancel Logout"
-msgstr "Ne pas se dé_connecter"
+msgstr "A_nnuler la demande de clôture de session"
 
 #: ../xed/xed-close-confirmation-dialog.c:134
 msgid "Close _without Saving"
-msgstr "_Fermer sans sauvegarder"
+msgstr "_Fermer sans enregistrer"
 
 #: ../xed/xed-close-confirmation-dialog.c:135 ../xed/xed-commands-file.c:399
 #: ../xed/xed-commands-file.c:502 ../xed/xed-commands-file.c:648
@@ -129,21 +132,21 @@ msgstr "_Fermer sans sauvegarder"
 #: ../xed/resources/ui/xed-highlight-mode-dialog.ui.h:2
 #: ../plugins/filebrowser/xed-file-browser-utils.c:153
 msgid "_Cancel"
-msgstr ""
+msgstr "_Annuler"
 
 #: ../xed/xed-close-confirmation-dialog.c:155
 msgid "_Save As..."
-msgstr ""
+msgstr "Enregi_strer sous..."
 
 #. File menu
 #: ../xed/xed-close-confirmation-dialog.c:161 ../xed/xed-commands-file.c:649
 #: ../xed/xed-ui.h:81
 msgid "_Save"
-msgstr ""
+msgstr "_Enregistrer"
 
 #: ../xed/xed-close-confirmation-dialog.c:188
 msgid "Question"
-msgstr ""
+msgstr "Question"
 
 #: ../xed/xed-close-confirmation-dialog.c:379
 #, c-format
@@ -153,12 +156,18 @@ msgid_plural ""
 "If you don't save, changes from the last %ld seconds will be permanently "
 "lost."
 msgstr[0] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis une seconde "
+"seront définitivement perdues."
 msgstr[1] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis %ld secondes "
+"seront définitivement perdues."
 
 #: ../xed/xed-close-confirmation-dialog.c:388
 msgid ""
 "If you don't save, changes from the last minute will be permanently lost."
 msgstr ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis une minute "
+"seront définitivement perdues."
 
 #: ../xed/xed-close-confirmation-dialog.c:393
 #, c-format
@@ -169,7 +178,11 @@ msgid_plural ""
 "If you don't save, changes from the last minute and %ld seconds will be "
 "permanently lost."
 msgstr[0] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis une minute et "
+"une seconde seront définitivement perdues."
 msgstr[1] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis une minute et "
+"%ld secondes seront définitivement perdues."
 
 #: ../xed/xed-close-confirmation-dialog.c:402
 #, c-format
@@ -179,12 +192,18 @@ msgid_plural ""
 "If you don't save, changes from the last %ld minutes will be permanently "
 "lost."
 msgstr[0] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis une minute "
+"seront définitivement perdues."
 msgstr[1] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis %ld minutes "
+"seront définitivement perdues."
 
 #: ../xed/xed-close-confirmation-dialog.c:417
 msgid ""
 "If you don't save, changes from the last hour will be permanently lost."
 msgstr ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis une heure "
+"seront définitivement perdues."
 
 #: ../xed/xed-close-confirmation-dialog.c:422
 #, c-format
@@ -195,7 +214,11 @@ msgid_plural ""
 "If you don't save, changes from the last hour and %d minutes will be "
 "permanently lost."
 msgstr[0] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis une heure et "
+"une minute seront définitivement perdues."
 msgstr[1] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis une heure et "
+"%d minutes seront définitivement perdues."
 
 #: ../xed/xed-close-confirmation-dialog.c:436
 #, c-format
@@ -204,12 +227,18 @@ msgid ""
 msgid_plural ""
 "If you don't save, changes from the last %d hours will be permanently lost."
 msgstr[0] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis une heure "
+"seront définitivement perdues."
 msgstr[1] ""
+"Si vous n'enregistrez pas, les modifications effectuées depuis %d heures "
+"seront définitivement perdues."
 
 #: ../xed/xed-close-confirmation-dialog.c:477
 #, c-format
 msgid "Save changes to document \"%s\" before closing?"
 msgstr ""
+"Voulez-vous enregistrer les modifications du document « %s » avant de le "
+"fermer?"
 
 #: ../xed/xed-close-confirmation-dialog.c:642
 #, c-format
@@ -218,70 +247,76 @@ msgid ""
 msgid_plural ""
 "There are %d documents with unsaved changes. Save changes before closing?"
 msgstr[0] ""
+"Il y a un document avec des modifications non enregistrées. Voulez-vous "
+"enregistrer les modifications avant de le fermer?"
 msgstr[1] ""
+"Il y a %d documents avec des modifications non enregistrées. Voulez-vous "
+"enregistrer les modifications avant de le fermer?"
 
 #: ../xed/xed-close-confirmation-dialog.c:659
 msgid "S_elect the documents you want to save:"
-msgstr ""
+msgstr "_Sélectionnez les documents que vous souhaitez enregistrer:"
 
 #. Secondary label
 #: ../xed/xed-close-confirmation-dialog.c:675
 msgid "If you don't save, all your changes will be permanently lost."
 msgstr ""
+"Si vous n'enregistrez pas, toutes vos modifications seront définitivement "
+"perdues."
 
 #: ../xed/xed-commands-file.c:229
 #, c-format
 msgid "Loading file '%s'…"
-msgstr ""
+msgstr "Chargement du fichier « %s »…"
 
 #: ../xed/xed-commands-file.c:238
 #, c-format
 msgid "Loading %d file…"
 msgid_plural "Loading %d files…"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Chargement d'un fichier…"
+msgstr[1] "Chargement de %d fichiers…"
 
 #. Translators: "Open Files" is the title of the file chooser window
 #: ../xed/xed-commands-file.c:395
 msgid "Open Files"
-msgstr ""
+msgstr "Ouverture de fichiers"
 
 #: ../xed/xed-commands-file.c:400
 #: ../plugins/filebrowser/xed-file-browser-widget.c:764
 msgid "_Open"
-msgstr ""
+msgstr "_Ouvrir"
 
 #: ../xed/xed-commands-file.c:494
 #, c-format
 msgid "The file \"%s\" is read-only."
-msgstr ""
+msgstr "Le fichier « %s » est en lecture seule."
 
 #: ../xed/xed-commands-file.c:499
 msgid "Do you want to try to replace it with the one you are saving?"
-msgstr ""
+msgstr "Voulez-vous le remplacer par celui que vous essayez d'enregistrer?"
 
 #: ../xed/xed-commands-file.c:503 ../xed/xed-ui.h:124
 msgid "_Replace"
-msgstr ""
+msgstr "R_emplacer"
 
 #: ../xed/xed-commands-file.c:564 ../xed/xed-commands-file.c:801
 #, c-format
 msgid "Saving file '%s'…"
-msgstr ""
+msgstr "Enregistrement du fichier « %s »…"
 
 #: ../xed/xed-commands-file.c:644
 msgid "Save As…"
-msgstr ""
+msgstr "Enregistrer sous…"
 
 #: ../xed/xed-commands-file.c:1202
 #, c-format
 msgid "Reverting the document '%s'…"
-msgstr ""
+msgstr "Récupération du document « %s »…"
 
 #: ../xed/xed-commands-file.c:1249
 #, c-format
 msgid "Revert unsaved changes to document '%s'?"
-msgstr ""
+msgstr "Annuler les modifications non enregistrées du document « %s »?"
 
 #: ../xed/xed-commands-file.c:1256
 #, c-format
@@ -291,12 +326,18 @@ msgid_plural ""
 "Changes made to the document in the last %ld seconds will be permanently "
 "lost."
 msgstr[0] ""
+"Les modifications effectuées au document depuis une seconde seront "
+"définitivement perdues."
 msgstr[1] ""
+"Les modifications effectuées au document depuis %ld secondes seront "
+"définitivement perdues."
 
 #: ../xed/xed-commands-file.c:1265
 msgid ""
 "Changes made to the document in the last minute will be permanently lost."
 msgstr ""
+"Les modifications effectuées au document depuis une minute seront "
+"définitivement perdues."
 
 #: ../xed/xed-commands-file.c:1270
 #, c-format
@@ -307,7 +348,11 @@ msgid_plural ""
 "Changes made to the document in the last minute and %ld seconds will be "
 "permanently lost."
 msgstr[0] ""
+"Les modifications effectuées au document depuis une minute et une seconde "
+"seront définitivement perdues."
 msgstr[1] ""
+"Les modifications effectuées au document depuis une minute et %ld secondes "
+"seront définitivement perdues."
 
 #: ../xed/xed-commands-file.c:1279
 #, c-format
@@ -317,12 +362,18 @@ msgid_plural ""
 "Changes made to the document in the last %ld minutes will be permanently "
 "lost."
 msgstr[0] ""
+"Les modifications effectuées au document depuis une minute seront "
+"définitivement perdues."
 msgstr[1] ""
+"Les modifications effectuées au document depuis %ld minutes seront "
+"définitivement perdues."
 
 #: ../xed/xed-commands-file.c:1294
 msgid ""
 "Changes made to the document in the last hour will be permanently lost."
 msgstr ""
+"Les modifications apportées au document durant la dernière heure seront "
+"définitivement perdues."
 
 #: ../xed/xed-commands-file.c:1299
 #, c-format
@@ -333,7 +384,11 @@ msgid_plural ""
 "Changes made to the document in the last hour and %d minutes will be "
 "permanently lost."
 msgstr[0] ""
+"Les modifications effectuées au document depuis une heure et une minute "
+"seront définitivement perdues."
 msgstr[1] ""
+"Les modifications effectuées au document depuis une heure et %d minutes "
+"seront définitivement perdues."
 
 #: ../xed/xed-commands-file.c:1313
 #, c-format
@@ -342,139 +397,145 @@ msgid ""
 msgid_plural ""
 "Changes made to the document in the last %d hours will be permanently lost."
 msgstr[0] ""
+"Les modifications effectuées au document durant la dernière heure seront "
+"définitivement perdues."
 msgstr[1] ""
+"Les modifications effectuées au document durant les %d dernières heures "
+"seront définitivement perdues."
 
 #: ../xed/xed-commands-file.c:1334
 msgid "_Revert"
-msgstr ""
+msgstr "_Rétablir"
 
 #: ../xed/xed-commands-help.c:55
 msgid "A small and lightweight text editor"
-msgstr ""
+msgstr "Un éditeur de texte petit et léger"
 
 #: ../xed/xed-document.c:973 ../xed/xed-document.c:1005
 #, c-format
 msgid "Unsaved Document %d"
-msgstr ""
+msgstr "Document %d non enregistré"
 
 #: ../xed/xed-documents-panel.c:88 ../xed/xed-documents-panel.c:99
-#: ../xed/xed-window.c:1890 ../xed/xed-window.c:1894
+#: ../xed/xed-window.c:1836 ../xed/xed-window.c:1840
 msgid "Read-Only"
-msgstr ""
+msgstr "Lecture seule"
 
 #: ../xed/xed-documents-panel.c:650 ../xed/resources/ui/xed-shortcuts.ui.h:1
-#: ../xed/xed-window.c:3140
+#: ../xed/xed-window.c:3086
 msgid "Documents"
-msgstr ""
+msgstr "Documents"
 
 #: ../xed/xed-encodings-combo-box.c:258
 msgid "Automatically Detected"
-msgstr ""
+msgstr "Détecté automatiquement"
 
 #: ../xed/xed-encodings-combo-box.c:277 ../xed/xed-encodings-combo-box.c:291
 #, c-format
 msgid "Current Locale (%s)"
-msgstr ""
+msgstr "Locale actuelle (%s)"
 
 #: ../xed/xed-encodings-combo-box.c:338
 msgid "Add or Remove..."
-msgstr ""
+msgstr "Ajouter ou supprimer..."
 
 #: ../xed/xed-encodings-dialog.c:331 ../plugins/time/xed-time-plugin.c:786
 msgid "_OK"
-msgstr ""
+msgstr "_Valider"
 
 #: ../xed/xed-encodings-dialog.c:332 ../xed/xed-ui.h:50
 #: ../plugins/spell/xed-spell-plugin.c:435
 msgid "_Help"
-msgstr ""
+msgstr "Aid_e"
 
 #: ../xed/xed-encodings-dialog.c:335
 msgid "Character Encodings"
-msgstr ""
+msgstr "Codages des caractères"
 
 #: ../xed/xed-encodings-dialog.c:368 ../xed/xed-encodings-dialog.c:405
 msgid "_Description"
-msgstr ""
+msgstr "_Description"
 
 #: ../xed/xed-encodings-dialog.c:376 ../xed/xed-encodings-dialog.c:413
 msgid "_Encoding"
-msgstr ""
+msgstr "_Codage"
 
 #: ../xed/xed-file-chooser-dialog.c:44 ../xed/xed-preferences-dialog.c:783
 msgid "All Files"
-msgstr ""
+msgstr "Tous les fichiers"
 
 #: ../xed/xed-file-chooser-dialog.c:45
 msgid "All Text Files"
-msgstr ""
+msgstr "Tous les fichiers texte"
 
 #: ../xed/xed-file-chooser-dialog.c:85
 msgid "C_haracter Encoding:"
-msgstr ""
+msgstr "_Codage de caractères:"
 
 #: ../xed/xed-file-chooser-dialog.c:141
 msgid "L_ine Ending:"
-msgstr ""
+msgstr "Fin de _ligne:"
 
 #: ../xed/xed-file-chooser-dialog.c:152
 msgid "Unix/Linux"
-msgstr ""
+msgstr "Unix/Linux"
 
 #: ../xed/xed-file-chooser-dialog.c:153
 msgid "Mac OS Classic"
-msgstr ""
+msgstr "Mac OS Classic"
 
 #: ../xed/xed-file-chooser-dialog.c:154
 msgid "Windows"
-msgstr ""
+msgstr "Windows"
 
-#: ../xed/xed-highlight-mode-selector.c:297 ../xed/xed-window.c:2019
+#: ../xed/xed-highlight-mode-selector.c:297 ../xed/xed-window.c:1965
 msgid "Plain Text"
-msgstr ""
+msgstr "Texte brut"
 
 #: ../xed/xed-io-error-info-bar.c:154 ../xed/xed-io-error-info-bar.c:390
 msgid "_Retry"
-msgstr ""
+msgstr "_Réessayer"
 
 #: ../xed/xed-io-error-info-bar.c:173
 #, c-format
 msgid "Could not find the file %s."
-msgstr ""
+msgstr "Impossible d'ouvrir le fichier %s."
 
 #: ../xed/xed-io-error-info-bar.c:174 ../xed/xed-io-error-info-bar.c:208
 #: ../xed/xed-io-error-info-bar.c:213
 msgid "Please check that you typed the location correctly and try again."
 msgstr ""
+"Vérifiez que vous avez correctement saisi l'emplacement et réessayez."
 
 #. Translators: %s is a URI scheme (like for example http:, ftp:, etc.)
 #: ../xed/xed-io-error-info-bar.c:189
 #, c-format
 msgid "xed cannot handle %s locations."
-msgstr ""
+msgstr "xed ne peut pas gérer les emplacements de %s."
 
 #: ../xed/xed-io-error-info-bar.c:194
 msgid "xed cannot handle this location."
-msgstr ""
+msgstr "xed ne peut pas gérer cet emplacement."
 
 #: ../xed/xed-io-error-info-bar.c:201
 msgid "The location of the file cannot be mounted."
-msgstr ""
+msgstr "L'emplacement du fichier ne peut pas être monté."
 
 #: ../xed/xed-io-error-info-bar.c:204
 msgid ""
 "The location of the file cannot be accessed because it is not mounted."
 msgstr ""
+"L'emplacement du fichier n'est pas accessible car il n'est pas monté."
 
 #: ../xed/xed-io-error-info-bar.c:207
 #, c-format
 msgid "%s is a directory."
-msgstr ""
+msgstr "%s est un dossier."
 
 #: ../xed/xed-io-error-info-bar.c:212
 #, c-format
 msgid "%s is not a valid location."
-msgstr ""
+msgstr "%s n'est pas un emplacement valide."
 
 #. Translators: %s is a host name
 #: ../xed/xed-io-error-info-bar.c:242
@@ -483,6 +544,7 @@ msgid ""
 "Host %s could not be found. Please check that your proxy settings are "
 "correct and try again."
 msgstr ""
+"L'hôte %s est introuvable. Vérifiez vos réglages de proxy et réessayez."
 
 #. use the same string as INVALID_HOST
 #: ../xed/xed-io-error-info-bar.c:256
@@ -491,152 +553,168 @@ msgid ""
 "Hostname was invalid. Please check that you typed the location correctly and "
 "try again."
 msgstr ""
+"Le nom d'hôte n'est pas valide. Vérifiez que vous avez correctement saisi "
+"son emplacement et réessayez."
 
 #: ../xed/xed-io-error-info-bar.c:263
 #, c-format
 msgid "%s is not a regular file."
-msgstr ""
+msgstr "%s n'est pas un fichier régulier."
 
 #: ../xed/xed-io-error-info-bar.c:266
 msgid "Connection timed out. Please try again."
-msgstr ""
+msgstr "Délai de connexion dépassé. Veuillez réessayer."
 
 #: ../xed/xed-io-error-info-bar.c:293
 #, c-format
 msgid "Unexpected error: %s"
-msgstr ""
+msgstr "Erreur inattendue : %s"
 
 #: ../xed/xed-io-error-info-bar.c:326
 msgid "xed cannot find the file. Perhaps it has recently been deleted."
-msgstr ""
+msgstr "xed ne trouve pas le fichier. Peut-être a-t-il récemment été supprimé."
 
 #: ../xed/xed-io-error-info-bar.c:336
 #, c-format
 msgid "Could not revert the file %s."
-msgstr ""
+msgstr "Impossible de récupérer le fichier %s."
 
 #: ../xed/xed-io-error-info-bar.c:359
 msgid "Ch_aracter Encoding:"
-msgstr ""
+msgstr "_Codage de caractères:"
 
 #. Translators: the access key chosen for this string should be
 #. different from other main menu access keys (Open, Edit, View...)
 #: ../xed/xed-io-error-info-bar.c:397 ../xed/xed-io-error-info-bar.c:654
 msgid "Edit Any_way"
-msgstr ""
+msgstr "Ou_vrir quand même"
 
 #: ../xed/xed-io-error-info-bar.c:489
 msgid ""
 "The number of followed links is limited and the actual file could not be "
 "found within this limit."
 msgstr ""
+"Le nombre de liens consécutifs est limité et le fichier actuel ne peut être "
+"trouvé en respectant cette limite."
 
 #: ../xed/xed-io-error-info-bar.c:493
 msgid "You do not have the permissions necessary to open the file."
-msgstr ""
+msgstr "Vous n'avez pas les droits nécessaires à l'ouverture du fichier."
 
 #: ../xed/xed-io-error-info-bar.c:499
 msgid "xed has not been able to detect the character encoding."
-msgstr ""
+msgstr "xed n'a pas été en mesure de détecter le codage de caractères."
 
 #: ../xed/xed-io-error-info-bar.c:501 ../xed/xed-io-error-info-bar.c:524
 msgid "Please check that you are not trying to open a binary file."
-msgstr ""
+msgstr "Vérifiez que vous n'essayez pas d'ouvrir un fichier binaire."
 
 #: ../xed/xed-io-error-info-bar.c:502
 msgid "Select a character encoding from the menu and try again."
-msgstr ""
+msgstr "Sélectionnez un codage de caractères dans le menu et réessayez."
 
 #: ../xed/xed-io-error-info-bar.c:508
 #, c-format
 msgid "There was a problem opening the file %s."
-msgstr ""
+msgstr "Un problème est apparu lors de l'ouverture du fichier %s."
 
 #: ../xed/xed-io-error-info-bar.c:509
 msgid ""
 "The file you opened has some invalid characters. If you continue editing "
 "this file you could corrupt this document."
 msgstr ""
+"Le fichier que vous avez ouvert contient des caractères non valides. Si vous "
+"poursuivez l'édition du fichier, vous pourriez endommager ce document."
 
 #: ../xed/xed-io-error-info-bar.c:512
 msgid "You can also choose another character encoding and try again."
 msgstr ""
+"Vous pouvez aussi choisir un autre codage de caractères et essayer à nouveau."
 
 #: ../xed/xed-io-error-info-bar.c:521
 #, c-format
 msgid "Could not open the file %s using the %s character encoding."
-msgstr ""
+msgstr "Impossible d'ouvrir le fichier %s avec le codage de caractères %s."
 
 #: ../xed/xed-io-error-info-bar.c:525 ../xed/xed-io-error-info-bar.c:594
 msgid "Select a different character encoding from the menu and try again."
 msgstr ""
+"Sélectionnez un codage de caractères différent dans le menu et réessayez."
 
 #: ../xed/xed-io-error-info-bar.c:537
 #, c-format
 msgid "Could not open the file %s."
-msgstr ""
+msgstr "Impossible d'ouvrir le fichier %s."
 
 #: ../xed/xed-io-error-info-bar.c:589
 #, c-format
 msgid "Could not save the file %s using the %s character encoding."
 msgstr ""
+"Impossible d'enregistrer le fichier %s avec le codage de caractères %s."
 
 #: ../xed/xed-io-error-info-bar.c:592
 msgid ""
 "The document contains one or more characters that cannot be encoded using "
 "the specified character encoding."
 msgstr ""
+"Le document contient un ou plusieurs caractères qui ne peuvent pas être "
+"représentés en utilisant le codage de caractères indiqué."
 
 #. Translators: the access key chosen for this string should be
 #. different from other main menu access keys (Open, Edit, View...)
 #: ../xed/xed-io-error-info-bar.c:659
 msgid "D_on't Edit"
-msgstr ""
+msgstr "Ne _pas éditer"
 
 #: ../xed/xed-io-error-info-bar.c:673
 #, c-format
 msgid "This file (%s) is already open in another xed window."
-msgstr ""
+msgstr "Ce fichier (%s) est déjà ouvert dans une autre fenêtre de xed."
 
 #: ../xed/xed-io-error-info-bar.c:687
 msgid ""
 "xed opened this instance of the file in a non-editable way. Do you want to "
 "edit it anyway?"
 msgstr ""
+"xed a ouvert cette instance du fichier dans un mode non éditable. Voulez-"
+"vous l'éditer quand même ?"
 
 #: ../xed/xed-io-error-info-bar.c:742 ../xed/xed-io-error-info-bar.c:830
 #: ../xed/xed-io-error-info-bar.c:1092
 msgid "S_ave Anyway"
-msgstr ""
+msgstr "_Enregistrer quand même"
 
 #: ../xed/xed-io-error-info-bar.c:743 ../xed/xed-io-error-info-bar.c:831
 #: ../xed/xed-io-error-info-bar.c:1094
 msgid "D_on't Save"
-msgstr ""
+msgstr "Ne _pas enregistrer"
 
 #. FIXME: review this message, it's not clear since for the user the "modification"
 #. * could be interpreted as the changes he made in the document. beside "reading" is
 #. * not accurate (since last load/save)
-#. 
+#.
 #: ../xed/xed-io-error-info-bar.c:760
 #, c-format
 msgid "The file %s has been modified since reading it."
-msgstr ""
+msgstr "Le fichier %s a été modifié depuis sa dernière lecture."
 
 #: ../xed/xed-io-error-info-bar.c:774
 msgid ""
 "If you save it, all the external changes could be lost. Save it anyway?"
 msgstr ""
+"Si vous l'enregistrez, toutes les modifications externes pourraient être "
+"perdues. Souhaitez-vous enregistrer quand même ?"
 
 #: ../xed/xed-io-error-info-bar.c:851
 #, c-format
 msgid "Could not create a backup file while saving %s"
 msgstr ""
+"Impossible de créer un fichier de sauvegarde lors de l'enregistrement de %s"
 
 #: ../xed/xed-io-error-info-bar.c:855
 #, c-format
 msgid "Could not create a temporary backup file while saving %s"
-msgstr ""
+msgstr "Impossible de créer un fichier de sauvegarde temporaire lors de l'enregistrement de %s"
 
 #: ../xed/xed-io-error-info-bar.c:871
 msgid ""
@@ -644,6 +722,10 @@ msgid ""
 "You can ignore this warning and save the file anyway, but if an error occurs "
 "while saving, you could lose the old copy of the file. Save anyway?"
 msgstr ""
+"xed n'a pas pu sauvegarder l'ancienne copie du fichier avant d'enregistrer "
+"la nouvelle. Vous pouvez ignorer cet avertissement et enregistrer le fichier "
+"malgré tout, mais si une erreur se produit lors de l'enregistrement, vous "
+"risquez de perdre l'ancienne copie du fichier. Enregistrer malgré tout ?"
 
 #. Translators: %s is a URI scheme (like for example http:, ftp:, etc.)
 #: ../xed/xed-io-error-info-bar.c:928
@@ -652,12 +734,16 @@ msgid ""
 "xed cannot handle %s locations in write mode. Please check that you typed "
 "the location correctly and try again."
 msgstr ""
+"xed ne peut pas gérer ces adresses %s en mode écriture. Veuillez vérifier "
+"que vous avez correctement saisi l'adresse et réessayer."
 
 #: ../xed/xed-io-error-info-bar.c:936
 msgid ""
 "xed cannot handle this location in write mode. Please check that you typed "
 "the location correctly and try again."
 msgstr ""
+"xed ne peut pas gérer cette adresse en mode écriture. Veuillez vérifier que "
+"vous avez correctement saisi l'adresse et réessayer."
 
 #: ../xed/xed-io-error-info-bar.c:945
 #, c-format
@@ -665,35 +751,46 @@ msgid ""
 "%s is not a valid location. Please check that you typed the location "
 "correctly and try again."
 msgstr ""
+"%s n'est pas un emplacement valide. Vérifiez que vous avez correctement "
+"saisi l'emplacement et réessayez."
 
 #: ../xed/xed-io-error-info-bar.c:951
 msgid ""
 "You do not have the permissions necessary to save the file. Please check "
 "that you typed the location correctly and try again."
 msgstr ""
+"Vous n'avez pas les permissions nécessaires pour enregistrer ce fichier. "
+"Vérifiez que vous avez correctement saisi l'emplacement et réessayez."
 
 #: ../xed/xed-io-error-info-bar.c:957
 msgid ""
 "There is not enough disk space to save the file. Please free some disk space "
 "and try again."
 msgstr ""
+"Il n'y a pas assez d'espace disque pour enregistrer le fichier. Libérez de "
+"l'espace disque et réessayez."
 
 #: ../xed/xed-io-error-info-bar.c:962
 msgid ""
 "You are trying to save the file on a read-only disk. Please check that you "
 "typed the location correctly and try again."
 msgstr ""
+"Vous essayez d'enregistrer le fichier vers un disque en lecture seule. "
+"Vérifiez que vous avez correctement saisi l'emplacement et réessayez."
 
 #: ../xed/xed-io-error-info-bar.c:968
 msgid ""
 "A file with the same name already exists. Please use a different name."
 msgstr ""
+"Un fichier possédant le même nom existe déjà. Veuillez utiliser un nom différent."
 
 #: ../xed/xed-io-error-info-bar.c:973
 msgid ""
 "The disk where you are trying to save the file has a limitation on length of "
 "the file names. Please use a shorter name."
 msgstr ""
+"Le disque sur lequel vous essayez d'enregistrer votre fichier limite la "
+"taille des noms de fichiers. Veuillez utiliser un nom plus court."
 
 #: ../xed/xed-io-error-info-bar.c:983
 msgid ""
@@ -701,11 +798,14 @@ msgid ""
 "sizes. Please try saving a smaller file or saving it to a disk that does not "
 "have this limitation."
 msgstr ""
+"Le disque sur lequel vous essayez d'enregistrer votre fichier limite la "
+"taille des fichiers. Essayez d'enregistrer un fichier plus petit ou "
+"d'enregistrer ce fichier sur un disque n'ayant pas de limitation."
 
 #: ../xed/xed-io-error-info-bar.c:996
 #, c-format
 msgid "Could not save the file %s."
-msgstr ""
+msgstr "Impossible d'enregistrer le fichier %s."
 
 #. FIXME: review this message, it's not clear since for the user the "modification"
 #. could be interpreted as the changes he made in the document. beside "reading" is
@@ -713,1251 +813,1249 @@ msgstr ""
 #: ../xed/xed-io-error-info-bar.c:1036
 #, c-format
 msgid "The file %s changed on disk."
-msgstr ""
+msgstr "Le fichier %s a été modifié sur disque."
 
 #: ../xed/xed-io-error-info-bar.c:1041
 msgid "Do you want to drop your changes and reload the file?"
-msgstr ""
+msgstr "Voulez-vous abandonner vos modifications et recharger le fichier?"
 
 #: ../xed/xed-io-error-info-bar.c:1045
 msgid "Do you want to reload the file?"
-msgstr ""
+msgstr "Voulez-vous recharger le fichier?"
 
 #: ../xed/xed-io-error-info-bar.c:1050
 msgid "_Reload"
-msgstr ""
+msgstr "Rec_harger"
 
 #: ../xed/xed-io-error-info-bar.c:1107
 #, c-format
 msgid "Some invalid chars have been detected while saving %s"
 msgstr ""
+"Des caractères non valides ont été détectés lors de l'enregistrement de %s"
 
 #: ../xed/xed-io-error-info-bar.c:1122
 msgid ""
 "If you continue saving this file you can corrupt the document.  Save anyway?"
 msgstr ""
+"Si vous poursuivez l'enregistrement de ce fichier vous pouvez endommager le "
+"document. Voulez-vous l'enregistrer néanmoins ?"
 
 #: ../xed/xed-preferences-dialog.c:280
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:3
 #, no-c-format
 msgid "Use the system fixed width font (%s)"
-msgstr ""
+msgstr "Utiliser la police de largeur fixe du système (%s)"
 
 #: ../xed/xed-preferences-dialog.c:436
 msgid "Editor"
-msgstr ""
+msgstr "Éditeur"
 
 #: ../xed/xed-preferences-dialog.c:474
 msgid "Save"
-msgstr ""
+msgstr "Enregistrer"
 
 #: ../xed/xed-preferences-dialog.c:587
 #, c-format
 msgid ""
 "Directory '%s' could not be created: g_mkdir_with_parents() failed: %s"
 msgstr ""
+"Impossible de créer le dossier « %s » : g_mkdir_with_parents() a échoué : %s"
 
 #: ../xed/xed-preferences-dialog.c:741
 msgid "The selected color scheme cannot be installed."
-msgstr ""
+msgstr "Le jeu de couleurs sélectionné ne peut pas être installé."
 
 #: ../xed/xed-preferences-dialog.c:764 ../xed/xed-preferences-dialog.c:770
 msgid "Add Scheme"
-msgstr ""
+msgstr "Ajout d'un jeu"
 
 #: ../xed/xed-preferences-dialog.c:767 ../xed/xed-progress-info-bar.c:61
 msgid "Cancel"
-msgstr ""
+msgstr "Annuler"
 
 #: ../xed/xed-preferences-dialog.c:776
 msgid "Color Scheme Files"
-msgstr ""
+msgstr "Fichiers de jeux de couleurs"
 
 #: ../xed/xed-preferences-dialog.c:848
 #, c-format
 msgid "Could not remove color scheme \"%s\"."
-msgstr ""
+msgstr "Impossible de supprimer le jeu de couleurs « %s »."
 
 #: ../xed/xed-preferences-dialog.c:880
 msgid "Theme"
-msgstr ""
+msgstr "Thème"
 
 #: ../xed/xed-preferences-dialog.c:897
 msgid "Plugins"
-msgstr ""
+msgstr "Greffons"
 
 #: ../xed/xed-preferences-dialog.c:905
 msgid "Help"
-msgstr ""
+msgstr "Aide"
 
 #: ../xed/xed-preferences-dialog.c:910
 #: ../xed/resources/ui/xed-searchbar.ui.h:11
 msgid "Close"
-msgstr ""
+msgstr "Fermer"
 
 #: ../xed/xed-preferences-dialog.c:924
 msgid "Xed Preferences"
-msgstr ""
+msgstr "Préférences de Xed"
 
 #: ../xed/xed-print-job.c:487
 #, c-format
 msgid "File: %s"
-msgstr ""
+msgstr "Fichier : %s"
 
 #: ../xed/xed-print-job.c:496
 msgid "Page %N of %Q"
-msgstr ""
+msgstr "Page %N sur %Q"
 
 #: ../xed/xed-print-job.c:733
 msgid "Preparing..."
-msgstr ""
+msgstr "Préparation..."
 
 #: ../xed/xed-print-preview.c:580
 msgid "Show the previous page"
-msgstr ""
+msgstr "Afficher la page précédente"
 
 #: ../xed/xed-print-preview.c:586
 msgid "Show the next page"
-msgstr ""
+msgstr "Afficher la page suivante"
 
 #: ../xed/xed-print-preview.c:600
 msgid "Current page (Alt+P)"
-msgstr ""
+msgstr "Page courante (Alt+P)"
 
 #. gtk_label_set_mnemonic_widget ((GtkLabel *) l, mp->priv->page_entry);
 #. We are displaying 'XXX of XXX'.
 #. Translators: the "of" from "1 of 19" in print preview.
 #: ../xed/xed-print-preview.c:614
 msgid "of"
-msgstr ""
+msgstr "sur"
 
 #: ../xed/xed-print-preview.c:619
 msgid "Page total"
-msgstr ""
+msgstr "Total de pages"
 
 #: ../xed/xed-print-preview.c:620
 msgid "The total number of pages in the document"
-msgstr ""
+msgstr "Le nombre total de pages dans le document"
 
 #: ../xed/xed-print-preview.c:640
 msgid "Show multiple pages"
-msgstr ""
+msgstr "Afficher les pages multiples"
 
 #: ../xed/xed-print-preview.c:658
 msgid "Zoom 1:1"
-msgstr ""
+msgstr "Zoom 1:1"
 
 #: ../xed/xed-print-preview.c:664
 msgid "Zoom to fit the whole page"
-msgstr ""
+msgstr "Affiche toute la page"
 
 #: ../xed/xed-print-preview.c:670
 msgid "Zoom the page in"
-msgstr ""
+msgstr "Zoom avant sur la page"
 
 #: ../xed/xed-print-preview.c:676
 msgid "Zoom the page out"
-msgstr ""
+msgstr "Zoom arrière sur la page"
 
 #: ../xed/xed-print-preview.c:693 ../xed/resources/ui/xed-shortcuts.ui.h:33
 msgid "Print the document"
-msgstr ""
+msgstr "Imprimer le document"
 
 #: ../xed/xed-print-preview.c:708
 msgid "_Close preview"
-msgstr ""
+msgstr "_Fermer la prévisualistion"
 
 #: ../xed/xed-print-preview.c:710
 msgid "Close print preview"
-msgstr ""
+msgstr "Fermer l'aperçu avant impression"
 
 #: ../xed/xed-print-preview.c:788
 #, c-format
 msgid "Page %d of %d"
-msgstr ""
+msgstr "Page %d de %d"
 
 #: ../xed/xed-print-preview.c:970
 msgid "Page Preview"
-msgstr ""
+msgstr "Aperçu de la page"
 
 #: ../xed/xed-print-preview.c:971
 msgid "The preview of a page in the document to be printed"
-msgstr ""
+msgstr "L'aperçu de la page dans le document à imprimer"
 
 #: ../xed/resources/ui/xed-highlight-mode-dialog.ui.h:1
 msgid "Highlight Mode"
-msgstr ""
+msgstr "Mode surligné"
 
 #: ../xed/resources/ui/xed-highlight-mode-dialog.ui.h:3
 msgid "_Select"
-msgstr ""
+msgstr "_Sélectionner"
 
 #: ../xed/resources/ui/xed-highlight-mode-selector.ui.h:1
 msgid "Search highlight mode…"
-msgstr ""
+msgstr "Recherche du mode de surlignage…"
 
 #: ../xed/resources/ui/xed-encodings-dialog.ui.h:1
 msgid "Character encodings"
-msgstr ""
+msgstr "Codages des caractères"
 
 #: ../xed/resources/ui/xed-encodings-dialog.ui.h:2
 msgid "A_vailable encodings:"
-msgstr ""
+msgstr "Codages _disponibles :"
 
 #: ../xed/resources/ui/xed-encodings-dialog.ui.h:3
 msgid "E_ncodings shown in menu:"
-msgstr ""
+msgstr "_Codages affichés dans le menu :"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:1
 msgid "Font"
-msgstr ""
+msgstr "Police"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:4
 msgid "Display"
-msgstr ""
+msgstr "Affichage"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:5
 msgid "Display line numbers"
-msgstr ""
+msgstr "Afficher les numéros de ligne"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:6
 msgid "Display overview map"
-msgstr ""
+msgstr "Afficher la carte d'aperçu"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:7
 msgid "Display right margin"
-msgstr ""
+msgstr "Afficher la marge de droite"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:8
 msgid "Right margin at column"
-msgstr ""
+msgstr "Marge de droite à la colonne"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:9
 msgid "4"
-msgstr ""
+msgstr "4"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:10
 msgid "Draw whitespace"
-msgstr ""
+msgstr "Dessiner les espaces"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:11
 msgid "Leading whitespace"
-msgstr ""
+msgstr "Espaces en préfix"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:12
 msgid "Trailing whitespace"
-msgstr ""
+msgstr "Espaces de surfix"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:13
 msgid "Whitespace inside of text"
-msgstr ""
+msgstr "Espaces à l'intérieur du texte"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:14
 msgid "Newline character"
-msgstr ""
+msgstr "Caractères de nouvelle ligne"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:15
 msgid "Highlighting"
-msgstr ""
+msgstr "Surlignage"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:16
 msgid "Highlight the current line"
-msgstr ""
+msgstr "Surligner la ligne courante"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:17
 msgid "Highlight matching brackets"
-msgstr ""
+msgstr "Montrer les parenthèses correspondantes"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:18
 msgid "Indentation"
-msgstr ""
+msgstr "Indentation"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:19
 msgid "Tab width"
-msgstr ""
+msgstr "Largeur des tabulations"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:20
 msgid "Use spaces instead of tabs"
-msgstr ""
+msgstr "Utiliser des espaces à la place des tabulations"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:21
 msgid "Automatic indentation"
-msgstr ""
+msgstr "Indentation automatique"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:22
 msgid "Word wrap"
-msgstr ""
+msgstr "Retour à la ligne"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:23
 msgid "Split words over two lines"
-msgstr ""
+msgstr "Couper les mots sur deux lignes"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:24
 msgid "Tab scrolling"
-msgstr ""
+msgstr "Défilement d'onglets"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:25
 msgid "Allow mouse wheel scrolling to change tabs"
-msgstr ""
+msgstr "Autoriser le changement d'onglet par la molette de la souris"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:26
 msgid "File saving"
-msgstr ""
+msgstr "Sauvegarde de fichiers"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:27
 msgid "Create a backup copy of files before saving"
-msgstr ""
+msgstr "Créer une copie avant la sauvegarde"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:28
 msgid "Autosave files"
-msgstr ""
+msgstr "Sauver les fichiers automatiquement"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:29
 msgid "Minutes between saving"
-msgstr ""
+msgstr "Minutes entre chaque sauvegarde"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:30
 msgid "Ensure Trailing Newline"
-msgstr ""
+msgstr "Assurer une nouvelle ligne terminale"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:31
 msgid "Dark theme"
-msgstr ""
+msgstr "Thème sombre"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:32
 msgid "Use dark theme variant (if available)"
-msgstr ""
+msgstr "Utiliser la variante sombre du thème (si disponible)"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:33
 msgid "Style scheme"
-msgstr ""
+msgstr "Jeu de style"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:34
 msgid "Install scheme"
-msgstr ""
+msgstr "Installer un jeu"
 
 #: ../xed/resources/ui/xed-preferences-dialog.ui.h:35
 msgid "Remove scheme"
-msgstr ""
+msgstr "Retirer le jeu"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:1
 msgid "Syntax Highlighting"
-msgstr ""
+msgstr "Coloration syntaxique"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:2
 msgid "Print synta_x highlighting"
-msgstr ""
+msgstr "Imprimer la coloration synta_xique"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:3
 msgid "Line Numbers"
-msgstr ""
+msgstr "Numéros de ligne"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:4
 msgid "Print line nu_mbers"
-msgstr ""
+msgstr "Imprimer les _numéros de ligne"
 
-#. 
+#.
 #: ../xed/resources/ui/xed-print-preferences.ui.h:6
 msgid "_Number every"
-msgstr ""
+msgstr "_Numéro toutes les"
 
-#. 
+#.
 #: ../xed/resources/ui/xed-print-preferences.ui.h:8
 msgid "lines"
-msgstr ""
+msgstr "lignes"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:9
 msgid "Text Wrapping"
-msgstr ""
+msgstr "Longues lignes"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:10
 msgid "Enable text _wrapping"
-msgstr ""
+msgstr "Activer le _retour à la ligne"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:11
 msgid "Do not _split words over two lines"
-msgstr ""
+msgstr "Ne pas _couper les mots sur deux lignes"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:12
 msgid "Page header"
-msgstr ""
+msgstr "En-tête de page"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:13
 msgid "Print page _headers"
-msgstr ""
+msgstr "Imprimer les _en-têtes de page"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:14
 msgid "Fonts"
-msgstr ""
+msgstr "Polices"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:15
 msgid "_Body:"
-msgstr ""
+msgstr "_Corps :"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:16
 msgid "_Line numbers:"
-msgstr ""
+msgstr "Numéros de _ligne :"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:17
 msgid "He_aders and footers:"
-msgstr ""
+msgstr "_En-têtes et pieds de page :"
 
 #: ../xed/resources/ui/xed-print-preferences.ui.h:18
 msgid "_Restore Default Fonts"
-msgstr ""
+msgstr "_Restaurer les polices par défaut"
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:1
 msgid "Replace All"
-msgstr ""
+msgstr "Tout remplacer"
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:2
 msgid "Replace"
-msgstr ""
+msgstr "Remplacer"
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:3
 msgid "_Search for: "
-msgstr ""
+msgstr "_Rechercher : "
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:4
 msgid "Replace _with: "
-msgstr ""
+msgstr "Remplacer _par : "
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:5
 msgid "Next"
-msgstr ""
+msgstr "Suivant"
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:6
 msgid "Previous"
-msgstr ""
+msgstr "Précédent"
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:7
 msgid "Regular expression"
-msgstr ""
+msgstr "Expression régulière"
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:8
 msgid "Case sensitive"
-msgstr ""
+msgstr "Sensible aux majuscules et minuscules"
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:9
 msgid "Whole word"
-msgstr ""
+msgstr "Mot entier"
 
 #: ../xed/resources/ui/xed-searchbar.ui.h:10
 msgid "Wrap"
-msgstr ""
+msgstr "Boucler"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:2 ../xed/xed-ui.h:56
 msgid "Create a new document"
-msgstr ""
+msgstr "Crée un nouveau document"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:3
 msgid "Open a document"
-msgstr ""
+msgstr "Ouvrir un document"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:4
 msgid "Save the document"
-msgstr ""
+msgstr "Enregistrer le document"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:5
 msgid "Save the document with a new filename"
-msgstr ""
+msgstr "Enregistrer le document sous un nom de fichier"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:6
 msgid "Save all the documents"
-msgstr ""
+msgstr "Enregistrer tous les documents"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:7
 msgid "Close the document"
-msgstr ""
+msgstr "Fermer le document"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:8
 msgid "Close all the documents"
-msgstr ""
+msgstr "Fermer tous les documents"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:9
 msgid "Switch to the next document"
-msgstr ""
+msgstr "Passer au document suivant"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:10
 msgid "Switch to the previous document"
-msgstr ""
+msgstr "Revenir au document précédent"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:11
 msgid "Switch to the first - ninth document"
-msgstr ""
+msgstr "Passer au premier - neuvième document"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:12
 msgid "Windows and Panes"
-msgstr ""
+msgstr "Fenêtres et panneaux"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:13
 msgid "Show side pane"
-msgstr ""
+msgstr "Afficher le panneau latéral"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:14
 msgid "Show bottom pane"
-msgstr ""
+msgstr "Afficher le panneau inférieur"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:15
 msgid "Fullscreen on / off"
-msgstr ""
+msgstr "Activer/désactiver le mode plein écran"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:16
 msgid "Quit the application"
-msgstr ""
+msgstr "Quitter l’application"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:17
 msgid "Find and Replace"
-msgstr ""
+msgstr "Rechercher et remplacer"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:18
 msgid "Find"
-msgstr ""
+msgstr "Rechercher"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:19
 msgid "Find the next match"
-msgstr ""
+msgstr "Rechercher la correspondance suivante"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:20
 msgid "Find the previous match"
-msgstr ""
+msgstr "Rechercher la correspondance précédente"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:21
 msgid "Go to line"
-msgstr ""
+msgstr "Aller à la ligne"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:22
 msgid "Copy and Paste"
-msgstr ""
+msgstr "Copier et coller"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:23
 msgid "Copy selected text to clipboard"
-msgstr ""
+msgstr "Copier le texte sélectionné dans le presse-papier"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:24
 msgid "Cut selected text to clipboard"
-msgstr ""
+msgstr "Couper le texte sélectionné dans le presse-papier"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:25
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Coller le texte sélectionné depuis le presse-papier"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:26
 msgid "Undo and Redo"
-msgstr ""
+msgstr "Annuler et refaire"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:27
 msgid "Undo previous command"
-msgstr ""
+msgstr "Annuler la commande précédente"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:28
 msgid "Redo previous command"
-msgstr ""
+msgstr "Refaire la commande précédente"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:29 ../plugins/docinfo/docinfo.ui.h:11
 msgid "Selection"
-msgstr ""
+msgstr "Sélection"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:30
 msgid "Select all text"
-msgstr ""
+msgstr "Sélectionner tout le texte"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:31
 msgid "Tools"
-msgstr ""
+msgstr "Outils"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:32
 msgid "Check spelling"
-msgstr ""
+msgstr "Vérifier l’orthographe"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:34
 msgid "Layout"
-msgstr ""
+msgstr "Disposition"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:35
 msgid "Toggle Word Wrap"
-msgstr ""
+msgstr "Activer, désativer le retour à la ligne automatique"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:36
 msgid "Editing"
-msgstr ""
+msgstr "Modification"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:37
 msgid "Toggle insert / overwrite"
-msgstr ""
+msgstr "Basculer insérer/écraser"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:38
 msgid "Delete current line"
-msgstr ""
+msgstr "Supprimer la ligne actuelle"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:39
 msgid "Move current line up"
-msgstr ""
+msgstr "Monter la ligne actuelle"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:40
 msgid "Move current line down"
-msgstr ""
+msgstr "Descendre la ligne actuelle"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:41
 msgid "Move current word left"
-msgstr ""
+msgstr "Déplacer le mot actuel vers la gauche"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:42
 msgid "Move current word right"
-msgstr ""
+msgstr "Déplacer le mot actuel vers la droite"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:43
 msgid "Convert to uppercase"
-msgstr ""
+msgstr "Convertir en majuscules"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:44
 msgid "Convert to lowercase"
-msgstr ""
+msgstr "Convertir en minuscules"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:45
 msgid "Convert to title case"
-msgstr ""
+msgstr "Convertir en casse de titre"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:46
 msgid "Invert case"
-msgstr ""
+msgstr "Inverser les majuscules/minuscules"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:47
 msgid "Increment number at cursor"
-msgstr ""
+msgstr "Incrémenter le nombre au curseur"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:48
 msgid "Decrement number at cursor"
-msgstr ""
+msgstr "Décrémenter le nombre au curseur"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:49
 msgid "Toggle comment block"
-msgstr ""
+msgstr "Commenter/Décommenter le bloc"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:50
 msgid "Toggle comment"
-msgstr ""
+msgstr "Commenter/Décommenter"
 
 #: ../xed/resources/ui/xed-shortcuts.ui.h:51
 #: ../plugins/joinlines/joinlines.plugin.desktop.in.h:1
 msgid "Join Lines"
-msgstr ""
+msgstr "Joindre les lignes"
 
 #: ../xed/xed-searchbar.c:88
 #, c-format
 msgid "Found and replaced %d occurrence"
 msgid_plural "Found and replaced %d occurrences"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Une occurrence trouvée et remplacée"
+msgstr[1] "%d occurrences trouvées et remplacées"
 
 #: ../xed/xed-searchbar.c:98
 msgid "Found and replaced one occurrence"
-msgstr ""
+msgstr "Une occurrence trouvée et remplacée"
 
 #: ../xed/xed-searchbar.c:120
 #, c-format
 msgid "\"%s\" not found"
-msgstr ""
+msgstr "« %s » n'a pas été trouvé"
 
 #: ../xed/xed-searchbar.c:298
 msgid "No matches found"
-msgstr ""
+msgstr "Aucun résultat trouvé"
 
 #: ../xed/xed-searchbar.c:306
 #, c-format
 msgid "%d match"
 msgid_plural "%d matches"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d résultat"
+msgstr[1] "%d résultats"
 
 #: ../xed/xed-searchbar.c:312
 #, c-format
 msgid "%d of %d match"
 msgid_plural "%d of %d matches"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d of %d résultat"
+msgstr[1] "%d of %d résultats"
 
 #: ../xed/xed-statusbar.c:63 ../xed/xed-statusbar.c:69
 msgid "OVR"
-msgstr ""
+msgstr "ECR"
 
 #: ../xed/xed-statusbar.c:63 ../xed/xed-statusbar.c:69
 msgid "INS"
-msgstr ""
+msgstr "INS"
 
 #. Translators: "Ln" is an abbreviation for "Line", Col is an abbreviation for "Column". Please,
 #. use abbreviations if possible to avoid space problems.
 #: ../xed/xed-statusbar.c:222
 #, c-format
 msgid "  Ln %d, Col %d"
-msgstr ""
+msgstr "  Lig %d, Col %d"
 
 #: ../xed/xed-statusbar.c:321
 #, c-format
 msgid "There is a tab with errors"
 msgid_plural "There are %d tabs with errors"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Il y a un onglet avec des erreurs"
+msgstr[1] "Il y a %d onglets avec des erreurs"
 
 #: ../xed/xed-tab-label.c:267
 msgid "Close document"
-msgstr ""
+msgstr "Fermer le document"
 
 #. Translators: the first %s is a file name (e.g. test.txt) the second one
 #. is a directory (e.g. ssh://master.gnome.org/home/users/paolo)
 #: ../xed/xed-tab.c:717
 #, c-format
 msgid "Reverting %s from %s"
-msgstr ""
+msgstr "Rétablissement de %s à partir de %s"
 
 #: ../xed/xed-tab.c:722
 #, c-format
 msgid "Reverting %s"
-msgstr ""
+msgstr "Rétablir %s"
 
 #. Translators: the first %s is a file name (e.g. test.txt) the second one
 #. is a directory (e.g. ssh://master.gnome.org/home/users/paolo)
 #: ../xed/xed-tab.c:735
 #, c-format
 msgid "Loading %s from %s"
-msgstr ""
+msgstr "Chargement de %s depuis %s"
 
 #: ../xed/xed-tab.c:740
 #, c-format
 msgid "Loading %s"
-msgstr ""
+msgstr "Chargement de %s"
 
 #. Translators: the first %s is a file name (e.g. test.txt) the second one
 #. is a directory (e.g. ssh://master.gnome.org/home/users/paolo)
 #: ../xed/xed-tab.c:821
 #, c-format
 msgid "Saving %s to %s"
-msgstr ""
+msgstr "Enregistrement de %s vers %s"
 
 #: ../xed/xed-tab.c:826
 #, c-format
 msgid "Saving %s"
-msgstr ""
+msgstr "Enregistrement de %s"
 
 #. Read only
 #: ../xed/xed-tab.c:1320
 msgid "RO"
-msgstr ""
+msgstr "RO"
 
 #: ../xed/xed-tab.c:1368
 #, c-format
 msgid "Error opening file %s"
-msgstr ""
+msgstr "Erreur lors de l'ouverture du fichier %s"
 
 #: ../xed/xed-tab.c:1372
 #, c-format
 msgid "Error reverting file %s"
-msgstr ""
+msgstr "Erreur lors du rétablissement du fichier %s"
 
 #: ../xed/xed-tab.c:1376
 #, c-format
 msgid "Error saving file %s"
-msgstr ""
+msgstr "Erreur lors de l'enregistrement du fichier %s"
 
 #: ../xed/xed-tab.c:1409
 msgid "Name:"
-msgstr ""
+msgstr "Nom :"
 
 #: ../xed/xed-tab.c:1410
 msgid "MIME Type:"
-msgstr ""
+msgstr "Type MIME :"
 
 #: ../xed/xed-tab.c:1411
 msgid "Encoding:"
-msgstr ""
+msgstr "Codage :"
 
 #. Toplevel
 #: ../xed/xed-ui.h:44
 msgid "_File"
-msgstr ""
+msgstr "_Fichier"
 
 #: ../xed/xed-ui.h:45
 msgid "_Edit"
-msgstr ""
+msgstr "É_dition"
 
 #: ../xed/xed-ui.h:46
 msgid "_View"
-msgstr ""
+msgstr "_Affichage"
 
 #: ../xed/xed-ui.h:47
 msgid "_Search"
-msgstr ""
+msgstr "_Rechercher"
 
 #: ../xed/xed-ui.h:48
 msgid "_Tools"
-msgstr ""
+msgstr "_Outils"
 
 #: ../xed/xed-ui.h:49
 msgid "_Documents"
-msgstr ""
+msgstr "Do_cuments"
 
 #: ../xed/xed-ui.h:51
 msgid "Favorites"
-msgstr ""
+msgstr "Favoris"
 
 #: ../xed/xed-ui.h:52
 msgid "Recents"
-msgstr ""
+msgstr "Récents"
 
 #. File menu
 #: ../xed/xed-ui.h:55
 msgid "_New"
-msgstr ""
+msgstr "_Nouveau"
 
 #: ../xed/xed-ui.h:57
 msgid "_Open..."
-msgstr ""
+msgstr "_Ouvrir..."
 
 #: ../xed/xed-ui.h:58
 msgid "Open a file"
-msgstr ""
+msgstr "Ouvrir un fichier"
 
 #. Edit menu
 #: ../xed/xed-ui.h:61
 msgid "Pr_eferences"
-msgstr ""
+msgstr "_Préférences"
 
 #: ../xed/xed-ui.h:62
 msgid "Configure the application"
-msgstr ""
+msgstr "Configurer l'application"
 
 #. Help menu
 #: ../xed/xed-ui.h:65
 msgid "_Contents"
-msgstr ""
+msgstr "_Sommaire"
 
 #: ../xed/xed-ui.h:66
 msgid "Open the xed manual"
-msgstr ""
+msgstr "Ouvrir le manuel de xed"
 
 #: ../xed/xed-ui.h:67
 msgid "_About"
-msgstr ""
+msgstr "À _propos"
 
 #: ../xed/xed-ui.h:68
 msgid "About this application"
-msgstr ""
+msgstr "À propos de cette application"
 
 #: ../xed/xed-ui.h:69
 msgid "_Keyboard Shortcuts"
-msgstr ""
+msgstr "Raccourcis _clavier"
 
 #: ../xed/xed-ui.h:70
 msgid "Show the keyboard shortcuts dialog"
-msgstr ""
+msgstr "Montrer les raccourcis clavier"
 
 #: ../xed/xed-ui.h:74
 msgid "Leave fullscreen mode"
-msgstr ""
+msgstr "Quitter le mode plein écran"
 
 #: ../xed/xed-ui.h:82
 msgid "Save the current file"
-msgstr ""
+msgstr "Enregistrer le fichier actuel"
 
 #: ../xed/xed-ui.h:83
 msgid "Save _As..."
-msgstr ""
+msgstr "Enregistrer _sous..."
 
 #: ../xed/xed-ui.h:84
 msgid "Save the current file with a different name"
-msgstr ""
+msgstr "Enregistrer le fichier actuel sous un nom différent"
 
 #: ../xed/xed-ui.h:85
 msgid "Revert"
-msgstr ""
+msgstr "Rétablir"
 
 #: ../xed/xed-ui.h:86
 msgid "Revert to a saved version of the file"
-msgstr ""
+msgstr "Récupérer une version enregistrée du fichier"
 
 #: ../xed/xed-ui.h:87
 msgid "Print Previe_w"
-msgstr ""
+msgstr "A_perçu avant impression"
 
 #: ../xed/xed-ui.h:88
 msgid "Print preview"
-msgstr ""
+msgstr "Aperçu avant impression"
 
 #: ../xed/xed-ui.h:89
 msgid "_Print..."
-msgstr ""
+msgstr "_Imprimer..."
 
 #: ../xed/xed-ui.h:90
 msgid "Print the current page"
-msgstr ""
+msgstr "Imprimer la page actuelle"
 
 #. Edit menu
 #: ../xed/xed-ui.h:93
 msgid "_Undo"
-msgstr ""
+msgstr "_Annuler"
 
 #: ../xed/xed-ui.h:94
 msgid "Undo the last action"
-msgstr ""
+msgstr "Annuler la dernière action"
 
 #: ../xed/xed-ui.h:95
 msgid "_Redo"
-msgstr ""
+msgstr "_Refaire"
 
 #: ../xed/xed-ui.h:96
 msgid "Redo the last undone action"
-msgstr ""
+msgstr "Refaire la dernière opération annulée"
 
 #: ../xed/xed-ui.h:97
 msgid "C_ut"
-msgstr ""
+msgstr "Co_uper"
 
 #: ../xed/xed-ui.h:98
 msgid "Cut the selection"
-msgstr ""
+msgstr "Couper la sélection"
 
 #: ../xed/xed-ui.h:99
 msgid "_Copy"
-msgstr ""
+msgstr "Co_pier"
 
 #: ../xed/xed-ui.h:100
 msgid "Copy the selection"
-msgstr ""
+msgstr "Copier la sélection"
 
 #: ../xed/xed-ui.h:101
 msgid "_Paste"
-msgstr ""
+msgstr "Co_ller"
 
 #: ../xed/xed-ui.h:102
 msgid "Paste the clipboard"
-msgstr ""
+msgstr "Coller le contenu du presse-papier"
 
 #: ../xed/xed-ui.h:103 ../plugins/filebrowser/xed-file-browser-plugin.c:962
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:997
 #: ../plugins/filebrowser/xed-file-browser-widget.c:758
 msgid "_Delete"
-msgstr ""
+msgstr "_Supprimer"
 
 #: ../xed/xed-ui.h:104
 msgid "Delete the selected text"
-msgstr ""
+msgstr "Supprimer le texte sélectionné"
 
 #: ../xed/xed-ui.h:105
 msgid "Select _All"
-msgstr ""
+msgstr "_Tout sélectionner"
 
 #: ../xed/xed-ui.h:106
 msgid "Select the entire document"
-msgstr ""
+msgstr "Sélectionner le document entier"
 
 #: ../xed/xed-ui.h:107
 msgid "_Toggle Comment"
-msgstr ""
+msgstr "_Commenter/Décommenter"
 
 #: ../xed/xed-ui.h:108 ../plugins/taglist/HTML.tags.xml.in.h:41
 msgid "Comment"
-msgstr ""
+msgstr "Commentaire"
 
 #: ../xed/xed-ui.h:109
 msgid "Toggle Comment _Block"
-msgstr ""
+msgstr "Commenter/Décommenter le _bloc"
 
 #: ../xed/xed-ui.h:110
 msgid "Comment Block"
-msgstr ""
+msgstr "Commenter le bloc"
 
 #. View menu
 #: ../xed/xed-ui.h:113
 msgid "_Highlight Mode"
-msgstr ""
+msgstr "Mode de _coloration"
 
 #: ../xed/xed-ui.h:114
 msgid "Change syntax hightlight mode"
-msgstr ""
+msgstr "Changer le mode de coloration syntaxique"
 
 #. Search menu
 #: ../xed/xed-ui.h:118
 msgid "_Find"
-msgstr ""
+msgstr "_Rechercher"
 
 #: ../xed/xed-ui.h:119
 msgid "Search for text"
-msgstr ""
+msgstr "Rechercher un texte"
 
 #: ../xed/xed-ui.h:120
 msgid "Find Ne_xt"
-msgstr ""
+msgstr "Rechercher le _suivant"
 
 #: ../xed/xed-ui.h:121
 msgid "Search forwards for the same text"
-msgstr ""
+msgstr "Rechercher vers l'avant le même texte"
 
 #: ../xed/xed-ui.h:122
 msgid "Find Pre_vious"
-msgstr ""
+msgstr "Rechercher le _précédent"
 
 #: ../xed/xed-ui.h:123
 msgid "Search backwards for the same text"
-msgstr ""
+msgstr "Rechercher en arrière le même texte"
 
 #: ../xed/xed-ui.h:125
 msgid "Search for and replace text"
-msgstr ""
+msgstr "Rechercher un texte et le remplacer"
 
 #: ../xed/xed-ui.h:126
 msgid "Go to _Line..."
-msgstr ""
+msgstr "Aller à la _ligne..."
 
 #: ../xed/xed-ui.h:127
 msgid "Go to a specific line"
-msgstr ""
+msgstr "Aller à une ligne spécifique"
 
 #. Documents menu
 #: ../xed/xed-ui.h:130
 msgid "_Save All"
-msgstr ""
+msgstr "Tout _enregistrer"
 
 #: ../xed/xed-ui.h:131
 msgid "Save all open files"
-msgstr ""
+msgstr "Enregistrer tous les fichiers ouverts"
 
 #: ../xed/xed-ui.h:132
 msgid "_Close All"
-msgstr ""
+msgstr "Tout _fermer"
 
 #: ../xed/xed-ui.h:133
 msgid "Close all open files"
-msgstr ""
+msgstr "Fermer tous les fichiers ouverts"
 
 #: ../xed/xed-ui.h:134
 msgid "_Previous Document"
-msgstr ""
+msgstr "Document _précédent"
 
 #: ../xed/xed-ui.h:135
 msgid "Activate previous document"
-msgstr ""
+msgstr "Activer le document précédent"
 
 #: ../xed/xed-ui.h:136
 msgid "_Next Document"
-msgstr ""
+msgstr "Document _suivant"
 
 #: ../xed/xed-ui.h:137
 msgid "Activate next document"
-msgstr ""
+msgstr "Activer le document suivant"
 
 #: ../xed/xed-ui.h:138
 msgid "_Move to New Window"
-msgstr ""
+msgstr "_Déplacer dans une nouvelle fenêtre"
 
 #: ../xed/xed-ui.h:139
 msgid "Move the current document to a new window"
-msgstr ""
+msgstr "Déplacer le document courant dans une nouvelle fenêtre"
 
 #: ../xed/xed-ui.h:145
 msgid "_Close"
-msgstr ""
+msgstr "_Fermer"
 
 #: ../xed/xed-ui.h:146
 msgid "Close the current file"
-msgstr ""
+msgstr "Ferme le fichier courant"
 
 #: ../xed/xed-ui.h:152
 msgid "_Quit"
-msgstr ""
+msgstr "_Quitter"
 
 #: ../xed/xed-ui.h:153
 msgid "Quit the program"
-msgstr ""
+msgstr "Quitter le programme"
 
 #: ../xed/xed-ui.h:158
 msgid "_Toolbar"
-msgstr ""
+msgstr "Barre d'_outils"
 
 #: ../xed/xed-ui.h:159
 msgid "Show or hide the toolbar in the current window"
-msgstr ""
+msgstr "Afficher ou cacher la barre d'outils dans la fenêtre actuelle"
 
 #: ../xed/xed-ui.h:161
-msgid "_Menubar"
-msgstr ""
+msgid "_Statusbar"
+msgstr "Barre d'é_tat"
 
 #: ../xed/xed-ui.h:162
-msgid "Show or hide the menubar in the current window"
-msgstr ""
+msgid "Show or hide the statusbar in the current window"
+msgstr "Afficher ou cacher la barre d'état dans la fenêtre actuelle"
 
 #: ../xed/xed-ui.h:164
-msgid "_Statusbar"
-msgstr ""
+msgid "Fullscreen"
+msgstr "Plein écran"
 
 #: ../xed/xed-ui.h:165
-msgid "Show or hide the statusbar in the current window"
-msgstr ""
+msgid "Edit text in fullscreen"
+msgstr "Éditer le texte en plein écran"
 
 #: ../xed/xed-ui.h:167
-msgid "Fullscreen"
-msgstr ""
+msgid "_Word wrap"
+msgstr "_Retour à la ligne"
 
 #: ../xed/xed-ui.h:168
-msgid "Edit text in fullscreen"
-msgstr ""
+msgid "Set word wrap for the current document"
+msgstr "Définir le retour à la ligne pour le document courant"
 
 #: ../xed/xed-ui.h:170
-msgid "_Word wrap"
-msgstr ""
+msgid "_Overview Map"
+msgstr "_Carte d'aperçu"
 
 #: ../xed/xed-ui.h:171
-msgid "Set word wrap for the current document"
-msgstr ""
-
-#: ../xed/xed-ui.h:173
-msgid "_Overview Map"
-msgstr ""
-
-#: ../xed/xed-ui.h:174
 msgid "Show or hide the overview map for the current view"
-msgstr ""
+msgstr "Montrer ou cacher la carte d'aperçu"
+
+#: ../xed/xed-ui.h:178
+msgid "Side _Pane"
+msgstr "Panneau _latéral"
+
+#: ../xed/xed-ui.h:179
+msgid "Show or hide the side pane in the current window"
+msgstr "Afficher ou cacher le panneau latéral dans la fenêtre actuelle"
 
 #: ../xed/xed-ui.h:181
-msgid "Side _Pane"
-msgstr ""
+msgid "_Bottom Pane"
+msgstr "Panneau _inférieur"
 
 #: ../xed/xed-ui.h:182
-msgid "Show or hide the side pane in the current window"
-msgstr ""
-
-#: ../xed/xed-ui.h:184
-msgid "_Bottom Pane"
-msgstr ""
-
-#: ../xed/xed-ui.h:185
 msgid "Show or hide the bottom pane in the current window"
-msgstr ""
+msgstr "Afficher ou cacher le panneau inférieur dans la fenêtre actuelle"
 
 #: ../xed/xed-utils.c:829
 msgid "Please check your installation."
-msgstr ""
+msgstr "Vérifiez votre installation."
 
 #: ../xed/xed-utils.c:897
 #, c-format
 msgid "Unable to open UI file %s. Error: %s"
-msgstr ""
+msgstr "Impossible d'ouvrir le fichier d'interface %s. Erreur : %s"
 
 #: ../xed/xed-utils.c:917
 #, c-format
 msgid "Unable to find the object '%s' inside file %s."
-msgstr ""
+msgstr "Impossible de trouver l'objet « %s » dans le fichier %s."
 
 #. Translators: '/ on <remote-share>'
 #: ../xed/xed-utils.c:1085
 #, c-format
 msgid "/ on %s"
-msgstr ""
+msgstr "/ sur %s"
 
 #: ../xed/xed-view.c:388
 msgid "_Display line numbers"
-msgstr ""
+msgstr "Afficher les _numéros de ligne"
 
 #. Translators: %s is a URI
-#: ../xed/xed-window.c:928
+#: ../xed/xed-window.c:878
 #, c-format
 msgid "Open '%s'"
-msgstr ""
+msgstr "Ouvrir '%s'"
 
 #. Translators: %s is a URI
-#: ../xed/xed-window.c:1279
+#: ../xed/xed-window.c:1226
 #, c-format
 msgid "Activate '%s'"
-msgstr ""
+msgstr "Activer « %s »"
 
-#: ../xed/xed-window.c:1467
+#: ../xed/xed-window.c:1414
 #, c-format
 msgid "Spaces: %u"
-msgstr ""
+msgstr "Espaces: %u"
 
-#: ../xed/xed-window.c:1471
+#: ../xed/xed-window.c:1418
 #, c-format
 msgid "Tabs: %u"
-msgstr ""
+msgstr "Tabulations: %u"
 
-#: ../xed/xed-window.c:1548
+#: ../xed/xed-window.c:1495
 msgid "Use Spaces"
-msgstr ""
+msgstr "Utiliser des espaces"
 
-#: ../xed/xed-window.c:2356
+#: ../xed/xed-window.c:2302
 msgid "There are unsaved documents"
-msgstr ""
+msgstr "Il y a des documents non enregistrés"
 
-#: ../xed/xed-window.c:3405
+#: ../xed/xed-window.c:3351
 msgid "Elevated Privileges"
-msgstr ""
+msgstr "Privilèges élevés"
 
 #: ../plugins/docinfo/docinfo.plugin.desktop.in.h:1
 #: ../plugins/docinfo/docinfo.ui.h:1
 msgid "Document Statistics"
-msgstr ""
+msgstr "Statistiques du document"
 
 #: ../plugins/docinfo/docinfo.plugin.desktop.in.h:2
 msgid ""
 "Analyzes the current document and reports the number of words, lines, "
 "characters and non-space characters in it."
 msgstr ""
+"Analyse le document actuel et rapporte le nombre de mots, de lignes, de "
+"caractères (avec et sans les espaces) qu'il contient."
 
 #: ../plugins/docinfo/docinfo.ui.h:2
 msgid "_Update"
-msgstr ""
+msgstr "_Mettre à jour"
 
 #: ../plugins/docinfo/docinfo.ui.h:3
 msgid "File Name"
-msgstr ""
+msgstr "Nom du fichier"
 
 #: ../plugins/docinfo/docinfo.ui.h:4 ../plugins/time/xed-time-dialog.ui.h:4
 #: ../plugins/time/xed-time-setup-dialog.ui.h:3
 msgid "    "
-msgstr ""
+msgstr "    "
 
 #: ../plugins/docinfo/docinfo.ui.h:5
 msgid "Bytes"
-msgstr ""
+msgstr "Octets"
 
 #: ../plugins/docinfo/docinfo.ui.h:6
 msgid "Characters (no spaces)"
-msgstr ""
+msgstr "Caractères (sans espaces)"
 
 #: ../plugins/docinfo/docinfo.ui.h:7
 msgid "Characters (with spaces)"
-msgstr ""
+msgstr "Caractères (avec espaces)"
 
 #: ../plugins/docinfo/docinfo.ui.h:8
 msgid "Words"
-msgstr ""
+msgstr "Mots"
 
 #: ../plugins/docinfo/docinfo.ui.h:9
 msgid "Lines"
-msgstr ""
+msgstr "Lignes"
 
 #: ../plugins/docinfo/docinfo.ui.h:10
 msgid "Document"
-msgstr ""
+msgstr "Document"
 
 #: ../plugins/docinfo/xed-docinfo-plugin.c:379
 msgid "_Document Statistics"
-msgstr ""
+msgstr "_Statistiques du document"
 
 #: ../plugins/docinfo/xed-docinfo-plugin.c:381
 msgid "Get statistical information on the current document"
-msgstr ""
+msgstr "Obtenir des statistiques sur le document courant"
 
 #: ../plugins/filebrowser/filebrowser.plugin.desktop.in.h:1
 msgid "File Browser Pane"
-msgstr ""
+msgstr "Panneau du navigateur de fichiers"
 
 #: ../plugins/filebrowser/filebrowser.plugin.desktop.in.h:2
 msgid "Easy file access from the side pane"
-msgstr ""
+msgstr "Accès facile aux fichiers depuis le panneau latéral"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:1
 msgid "Set Location to First Document"
-msgstr ""
+msgstr "Définir l'emplacement au premier document"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:2
 msgid ""
@@ -1966,10 +2064,14 @@ msgid ""
 "generally applies to opening a document from the command line or opening it "
 "with Caja, etc.)"
 msgstr ""
+"Si VRAI, le greffon du gestionnaire de fichiers affichera le dossier du "
+"premier document ouvert dès lors que le gestionnaire de fichiers n'a pas "
+"encore été utilisé. Ceci s'applique généralement à l'ouverture d'un document "
+"à partir de la ligne de commande ou à partir de Caja, etc."
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:3
 msgid "File Browser Filter Mode"
-msgstr ""
+msgstr "Mode de filtre du gestionnaire de fichiers"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:4
 msgid ""
@@ -1978,48 +2080,58 @@ msgid ""
 "(filter binary files) and hidden_and_binary (filter both hidden and binary "
 "files)."
 msgstr ""
+"Cette valeur détermine quels fichiers du gestionnaire de fichiers seront "
+"filtrés. Les valeurs possibles sont : « none » (ne filtre rien), « hidden » "
+"(filtre les fichiers cachés), « binary » (filtre les fichiers binaires) et "
+"« hidden_and_binary » (filtre à la fois les fichiers cachés et binaires)."
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:5
 msgid "File Browser Filter Pattern"
-msgstr ""
+msgstr "Motif de filtre du gestionnaire de fichiers"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:6
 msgid ""
 "The filter pattern to filter the file browser with. This filter works on top "
 "of the filter_mode."
 msgstr ""
+"Le motif du filtre à appliquer au gestionnaire de fichiers. Le "
+"fonctionnement de ce filtre est basé sur le mode filtre (filter_mode)."
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:7
 msgid "Terminal Command"
-msgstr ""
+msgstr "Commande du terminal"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:8
 msgid "The terminal command when using the \"Open terminal here\" command."
-msgstr ""
+msgstr "Commande associée à l'option \"Ouvrir un terminal ici\"."
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:9
 msgid "Open With Tree View"
-msgstr ""
+msgstr "Ouvrir avec la vue arborescente"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:10
 msgid ""
 "Open the tree view when the file browser plugin gets loaded instead of the "
 "bookmarks view"
 msgstr ""
+"Ouvre la vue arborescente quand le greffon du gestionnaire de fichiers est "
+"chargé à la place de la vue des signets"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:11
 msgid "File Browser Root Directory"
-msgstr ""
+msgstr "Dossier racine du gestionnaire de fichiers"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:12
 msgid ""
 "The file browser root directory to use when loading the file browser plugin "
 "and onload/tree_view is TRUE."
 msgstr ""
+"Le dossier du gestionnaire de fichiers à utiliser lors du lancement du "
+"greffon lorsque la vue arborescente au lancement (onload/tree_view) est VRAI."
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:13
 msgid "File Browser Virtual Root Directory"
-msgstr ""
+msgstr "Dossier racine virtuel du gestionnaire de fichiers"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:14
 msgid ""
@@ -2027,2036 +2139,2072 @@ msgid ""
 "plugin when onload/tree_view is TRUE. The virtual root must always be below "
 "the actual root."
 msgstr ""
+"Le dossier racine virtuel du gestionnaire de fichiers à utiliser lors du "
+"lancement du greffon lorsque la vue arborescente au lancement "
+"(onload/tree_view) est VRAI. Le dossier racine virtuel doit toujours être au-"
+"dessous de la racine actuelle."
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:15
 msgid "Enable Restore of Remote Locations"
-msgstr ""
+msgstr "Activer la restauration des emplacement distants"
 
 #: ../plugins/filebrowser/org.x.editor.plugins.filebrowser.gschema.xml.h:16
 msgid "Sets whether to enable restoring of remote locations."
-msgstr ""
+msgstr "Définit s'il faut activer la restauration des emplacements distants."
 
 #: ../plugins/filebrowser/xed-file-bookmarks-store.c:254
 msgid "File System"
-msgstr ""
+msgstr "Système de fichiers"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:439
 msgid "_Set root to active document"
-msgstr ""
+msgstr "_Définir la racine au document actif"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:441
 msgid "Set the root to the active document location"
-msgstr ""
+msgstr "Définir la racine à l'emplacement du document actif"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:446
 msgid "_Open terminal here"
-msgstr ""
+msgstr "_Ouvrir un terminal ici"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:448
 msgid "Open a terminal at the currently opened directory"
-msgstr ""
+msgstr "Ouvrir un terminal à partir du dossier ouvert courant"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:558
 msgid "File Browser"
-msgstr ""
+msgstr "Navigateur de fichiers"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:667
 msgid "An error occurred while creating a new directory"
-msgstr ""
+msgstr "Une erreur s'est produite lors de la création d'un nouveau dossier"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:670
 msgid "An error occurred while creating a new file"
-msgstr ""
+msgstr "Une erreur s'est produite lors de la création d'un nouveau fichier"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:673
 msgid "An error occurred while renaming a file or directory"
 msgstr ""
+"Une erreur s'est produite en renommant un fichier ou un dossier"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:676
 msgid "An error occurred while deleting a file or directory"
 msgstr ""
+"Une erreur s'est produite lors de la suppression d'un fichier ou d'un dossier"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:679
 msgid "An error occurred while opening a directory in the file manager"
 msgstr ""
+"Une erreur s'est produite lors de l'ouverture d'un dossier dans le "
+"gestionnaire de fichiers"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:682
 msgid "An error occurred while setting a root directory"
-msgstr ""
+msgstr "Une erreur s'est produite lors du paramétrage d'un dossier racine"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:685
 msgid "An error occurred while loading a directory"
-msgstr ""
+msgstr "Une erreur s'est produite lors du chargement d'un dossier"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:688
 msgid "An error occurred"
-msgstr ""
+msgstr "Une erreur s'est produite"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:945
 msgid ""
 "Cannot move file to trash, do you\n"
 "want to delete permanently?"
 msgstr ""
+"Impossible de mettre le fichier à la corbeille,\n"
+"voulez-vous le supprimer définitivement ?"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:950
 #, c-format
 msgid "The file \"%s\" cannot be moved to the trash."
-msgstr ""
+msgstr "Le fichier « %s » ne peut pas être mis à la corbeille."
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:955
 msgid "The selected files cannot be moved to the trash."
-msgstr ""
+msgstr "Les fichiers sélectionnés ne peuvent pas être mis à la corbeille."
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:983
 #, c-format
 msgid "Are you sure you want to permanently delete \"%s\"?"
-msgstr ""
+msgstr "Voulez-vous vraiment supprimer définitivement « %s » ?"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:988
 msgid "Are you sure you want to permanently delete the selected files?"
 msgstr ""
+"Voulez-vous vraiment supprimer définitivement les fichiers sélectionnés ?"
 
 #: ../plugins/filebrowser/xed-file-browser-plugin.c:991
 msgid "If you delete an item, it is permanently lost."
-msgstr ""
+msgstr "Si vous supprimez un élément, il sera définitivement perdu."
 
 #: ../plugins/filebrowser/xed-file-browser-store.c:1810
 msgid "(Empty)"
-msgstr ""
+msgstr "(vide)"
 
 #: ../plugins/filebrowser/xed-file-browser-store.c:3500
 msgid ""
 "The renamed file is currently filtered out. You need to adjust your filter "
 "settings to make the file visible"
 msgstr ""
+"Le fichier renommé est actuellement filtré. Ajustez les paramètres de votre "
+"filtre pour rendre le fichier visible"
 
 #. Translators: This is the default name of new files created by the file browser pane.
 #: ../plugins/filebrowser/xed-file-browser-store.c:3766
 msgid "Untitled File"
-msgstr ""
+msgstr "Document sans nom"
 
 #: ../plugins/filebrowser/xed-file-browser-store.c:3794
 msgid ""
 "The new file is currently filtered out. You need to adjust your filter "
 "settings to make the file visible"
 msgstr ""
+"Le nouveau fichier est actuellement filtré. Ajustez les paramètres de votre "
+"filtre pour rendre le fichier visible"
 
 #. Translators: This is the default name of new directories created by the file browser pane.
 #: ../plugins/filebrowser/xed-file-browser-store.c:3821
 msgid "Untitled Folder"
-msgstr ""
+msgstr "Nouveau dossier"
 
 #: ../plugins/filebrowser/xed-file-browser-store.c:3846
 msgid ""
 "The new directory is currently filtered out. You need to adjust your filter "
 "settings to make the directory visible"
 msgstr ""
+"Le nouveau dossier est actuellement filtré. Ajustez les paramètres de votre "
+"filtre pour rendre le dossier visible"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:714
 msgid "Bookmarks"
-msgstr ""
+msgstr "Signets"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:751
 msgid "_Filter"
-msgstr ""
+msgstr "_Filtrer"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:756
 msgid "_Move to Trash"
-msgstr ""
+msgstr "_Mettre à la corbeille"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:757
 msgid "Move selected file or folder to trash"
-msgstr ""
+msgstr "Mettre le fichier ou le dossier sélectionné à la corbeille"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:759
 msgid "Delete selected file or folder"
-msgstr ""
+msgstr "Supprimer le fichier ou le dossier sélectionné"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:765
 msgid "Open selected file"
-msgstr ""
+msgstr "Ouvrir le fichier sélectionné"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:770
 msgid "Up"
-msgstr ""
+msgstr "Haut"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:771
 msgid "Open the parent folder"
-msgstr ""
+msgstr "Ouvrir le dossier parent"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:776
 msgid "_New Folder"
-msgstr ""
+msgstr "_Nouveau dossier"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:777
 msgid "Add new empty folder"
-msgstr ""
+msgstr "Ajouter un nouveau dossier vide"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:778
 msgid "New F_ile"
-msgstr ""
+msgstr "Nouveau f_ichier"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:779
 msgid "Add new empty file"
-msgstr ""
+msgstr "Ajouter un nouveau fichier vide"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:784
 msgid "_Rename..."
-msgstr ""
+msgstr "_Renommer..."
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:785
 msgid "Rename selected file or folder"
-msgstr ""
+msgstr "Renommer le fichier ou le dossier sélectionné"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:790
 msgid "_Previous Location"
-msgstr ""
+msgstr "Emplacement _précédent"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:791
 msgid "Go to the previous visited location"
-msgstr ""
+msgstr "Aller à l'emplacement visité précédent"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:792
 msgid "_Next Location"
-msgstr ""
+msgstr "Emplacement _suivant"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:793
 msgid "Go to the next visited location"
-msgstr ""
+msgstr "Aller à l'emplacement visité suivant"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:794
 msgid "Re_fresh View"
-msgstr ""
+msgstr "_Actualiser l'affichage"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:795
 msgid "Refresh the view"
-msgstr ""
+msgstr "Actualiser l'affichage"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:796
 #: ../plugins/filebrowser/xed-file-browser-widget.c:810
 msgid "_View Folder"
-msgstr ""
+msgstr "A_fficher le dossier"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:797
 #: ../plugins/filebrowser/xed-file-browser-widget.c:811
 msgid "View folder in file manager"
-msgstr ""
+msgstr "Afficher le dossier dans le gestionnaire de fichiers"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:802
 msgid "Show _Hidden"
-msgstr ""
+msgstr "Afficher les fichiers _cachés"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:803
 msgid "Show hidden files and folders"
-msgstr ""
+msgstr "Afficher les fichiers et les dossiers cachés"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:804
 msgid "Show _Binary"
-msgstr ""
+msgstr "Afficher les _binaires"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:805
 msgid "Show binary files"
-msgstr ""
+msgstr "Afficher les fichiers binaires"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:1148
 msgid "_Match Filename"
-msgstr ""
+msgstr "Filtrer _nom de fichier"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:2012
 #, c-format
 msgid "No mount object for mounted volume: %s"
-msgstr ""
+msgstr "Aucun objet pour le volume monté : « %s »"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:2090
 #, c-format
 msgid "Could not open media: %s"
-msgstr ""
+msgstr "Impossible d'ouvrir le média : « %s »"
 
 #: ../plugins/filebrowser/xed-file-browser-widget.c:2139
 #, c-format
 msgid "Could not mount volume: %s"
-msgstr ""
+msgstr "Impossible de monter le volume « %s »"
 
 #: ../plugins/joinlines/joinlines.plugin.desktop.in.h:2
 msgid "Join several lines"
-msgstr ""
+msgstr "Fusionner plusieurs lignes"
 
 #: ../plugins/joinlines/joinlines/__init__.py:26
 msgid "_Join Lines"
-msgstr ""
+msgstr "_Fusionner les lignes"
 
 #: ../plugins/joinlines/joinlines/__init__.py:27
 msgid "Join the selected lines"
-msgstr ""
+msgstr "Fusionner les lignes sélectionnées"
 
 #. vi:ts=8
 #: ../plugins/modelines/modelines.plugin.desktop.in.h:1
 msgid "Modelines"
-msgstr ""
+msgstr "Modificateurs"
 
 #: ../plugins/modelines/modelines.plugin.desktop.in.h:2
 msgid "Emacs, Kate and Vim-style modelines support for xed."
-msgstr ""
+msgstr "Prise en charge des modes Emacs, Kate et Vim."
+
+#: ../plugins/rsort/rsort.plugin.desktop.in.h:1
+msgid "RSort"
+msgstr "TrierInv"
+
+#: ../plugins/rsort/rsort.plugin.desktop.in.h:2
+msgid "Reverse sorts a document or selected text."
+msgstr "Trier en ordre inverse un document ou le texte sélectionné."
+
+#: ../plugins/rsort/xed-rsort-plugin.c:78
+msgid "_RSort lines"
+msgstr "Trier en ordre _inverse les lignes"
+
+#: ../plugins/rsort/xed-rsort-plugin.c:80
+msgid "Reverse Sort the current document or selection"
+msgstr "Trier en ordre inverse le document actuel ou la sélection"
 
 #: ../plugins/sort/sort.plugin.desktop.in.h:1
 msgid "Sort"
-msgstr ""
+msgstr "Trier"
 
 #: ../plugins/sort/sort.plugin.desktop.in.h:2
 msgid "Sorts a document or selected text."
-msgstr ""
+msgstr "Trier un document ou le texte sélectionné."
 
 #: ../plugins/sort/xed-sort-plugin.c:75
 msgid "S_ort lines"
-msgstr ""
+msgstr "_Trier les lignes"
 
 #: ../plugins/sort/xed-sort-plugin.c:77
 msgid "Sort the current document or selection"
-msgstr ""
+msgstr "Trier le document actuel ou la sélection"
 
 #: ../plugins/spell/org.x.editor.plugins.spell.gschema.xml.in.h:1
 msgid "Autocheck Type"
-msgstr ""
+msgstr "Type de vérification automatique"
 
 #: ../plugins/spell/spell.plugin.desktop.in.h:1
 msgid "Spell Checker"
-msgstr ""
+msgstr "Vérificateur orthographique"
 
 #: ../plugins/spell/spell.plugin.desktop.in.h:2
 msgid "Checks the spelling of the current document."
-msgstr ""
+msgstr "Vérifier l'orthographe du document actuel."
 
 #: ../plugins/spell/xed-spell-plugin.c:86
 msgid "_Check Spelling..."
-msgstr ""
+msgstr "_Vérification orthographique..."
 
 #: ../plugins/spell/xed-spell-plugin.c:88
 msgid "Check the current document for incorrect spelling"
-msgstr ""
+msgstr "Vérifier l'orthographe du document actuel"
 
 #: ../plugins/spell/xed-spell-plugin.c:94
 msgid "Set _Language..."
-msgstr ""
+msgstr "Définir la _langue..."
 
 #: ../plugins/spell/xed-spell-plugin.c:96
 msgid "Set the language of the current document"
-msgstr ""
+msgstr "Définir la langue du document actuel"
 
 #: ../plugins/spell/xed-spell-plugin.c:105
 msgid "_Autocheck Spelling"
-msgstr ""
+msgstr "Vérification orthographique _automatique"
 
 #: ../plugins/spell/xed-spell-plugin.c:107
 msgid "Automatically spell-check the current document"
-msgstr ""
+msgstr "Vérifie automatiquement l'orthographe du document actuel"
 
 #: ../plugins/spell/xed-spell-setup-dialog.ui.h:1
 msgid "button"
-msgstr ""
+msgstr "bouton"
 
 #: ../plugins/spell/xed-spell-setup-dialog.ui.h:2
 msgid "Autocheck settings"
-msgstr ""
+msgstr "Réglages de vérification automatique"
 
 #: ../plugins/spell/xed-spell-setup-dialog.ui.h:3
 msgid "Never"
-msgstr ""
+msgstr "Jamais"
 
 #: ../plugins/spell/xed-spell-setup-dialog.ui.h:4
 msgid "Never autocheck spelling on document load"
 msgstr ""
+"Ne jamais vérifier automatiquement l'orthographe au chargement du document"
 
 #: ../plugins/spell/xed-spell-setup-dialog.ui.h:5
 msgid "Remember by document"
-msgstr ""
+msgstr "Mémoriser par document"
 
 #: ../plugins/spell/xed-spell-setup-dialog.ui.h:6
 msgid "Remembers the setting for each  document on load"
-msgstr ""
+msgstr "Mémoriser le paramètre pour chaque document lors de son chargement"
 
 #: ../plugins/spell/xed-spell-setup-dialog.ui.h:7
 msgid "Always"
-msgstr ""
+msgstr "Toujours"
 
 #: ../plugins/spell/xed-spell-setup-dialog.ui.h:8
 msgid "Always autocheck on document load"
-msgstr ""
+msgstr "Toujours vérifier automatiquement au chargement du document"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:1
 msgid "XHTML 1.0 - Tags"
-msgstr ""
+msgstr "XHTML 1.0 - Balises"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:2
 msgid "Abbreviated form"
-msgstr ""
+msgstr "Formule abrégée"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:3
 msgid "Abbreviation"
-msgstr ""
+msgstr "Abréviation"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:4
 msgid "Accessibility key character"
-msgstr ""
+msgstr "Touche clavier d'accessibilité"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:5
 msgid "Acronym"
-msgstr ""
+msgstr "Acronyme"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:6
 msgid "Align"
-msgstr ""
+msgstr "Aligner"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:7
 msgid "Alignment character"
-msgstr ""
+msgstr "Caractère d'alignement"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:8
 msgid "Alternative"
-msgstr ""
+msgstr "Alternatif"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:9
 msgid "Anchor URI"
-msgstr ""
+msgstr "URI de l'ancre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:10
 msgid "Anchor"
-msgstr ""
+msgstr "Ancre"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:12
 msgid "Applet class file code (deprecated)"
-msgstr ""
+msgstr "Code source de classe d'applet (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:13
 msgid "Associated information"
-msgstr ""
+msgstr "Information associée"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:14
 msgid "Author info"
-msgstr ""
+msgstr "Information sur l'auteur"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:15
 msgid "Axis related headers"
-msgstr ""
+msgstr "En-têtes reliés aux axes"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:17
 msgid "Background color (deprecated)"
-msgstr ""
+msgstr "Couleur d'arrière-plan (obsolète)"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:19
 msgid "Background texture tile (deprecated)"
-msgstr ""
+msgstr "Texture d'arrière-plan (obsolète)"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:21
 msgid "Base font (deprecated)"
-msgstr ""
+msgstr "Police de base (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:22
 msgid "Base URI"
-msgstr ""
+msgstr "URI de base"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:23
 msgid "Bold"
-msgstr ""
+msgstr "Gras"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:25
 msgid "Border (deprecated)"
-msgstr ""
+msgstr "Bordure (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:26
 msgid "Cell rowspan"
-msgstr ""
+msgstr "Étendue horizontale de la cellule"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:28
 msgid "Center (deprecated)"
-msgstr ""
+msgstr "Centrer (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:29
 msgid "Character encoding of linked resource"
-msgstr ""
+msgstr "Codage de caractères de la ressource liée"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:30
 msgid "Checked state"
-msgstr ""
+msgstr "État coché"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:31
 msgid "Citation"
-msgstr ""
+msgstr "Citation"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:32
 msgid "Cite reason for change"
-msgstr ""
+msgstr "Indique le motif de la modification"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:33
 msgid "Class implementation ID"
-msgstr ""
+msgstr "ID de la classe d'implémentation"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:34
 msgid "Class list"
-msgstr ""
+msgstr "Liste des classes"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:35
 msgid "Clear text flow control"
-msgstr ""
+msgstr "Effacer le contrôle du flux du texte"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:36
 msgid "Code content type"
-msgstr ""
+msgstr "Code du type de contenu"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:38
 msgid "Color of selected links (deprecated)"
-msgstr ""
+msgstr "Couleur des liens sélectionnés (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:39
 msgid "Column span"
-msgstr ""
+msgstr "Extension sur plusieurs colonnes"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:40
 msgid "Columns"
-msgstr ""
+msgstr "Colonnes"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:42
 msgid "Computer code fragment"
-msgstr ""
+msgstr "Extrait de code"
 
 #. The "type" attribute is deprecated for the "ol" tag only,
 #. since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:45
 msgid "Content type (deprecated)"
-msgstr ""
+msgstr "Type de contenu (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:46
 msgid "Coordinates"
-msgstr ""
+msgstr "Coordonnées"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:47
 msgid "Date and time of change"
-msgstr ""
+msgstr "Date et heure de modification"
 
 #. NOTE: used in "object" tag
 #: ../plugins/taglist/HTML.tags.xml.in.h:49
 msgid "Declare flag"
-msgstr ""
+msgstr "Drapeau de déclaration"
 
 #. Translators: DEFER is an optional attribute of the <script> tag.
 #. It indicates that the script is not going to generate any document
 #. content. The browser can continue parsing and drawing the page.
 #: ../plugins/taglist/HTML.tags.xml.in.h:53
 msgid "Defer attribute"
-msgstr ""
+msgstr "Attribut déféré"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:54
 msgid "Definition description"
-msgstr ""
+msgstr "Description de la définition"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:55
 msgid "Definition list"
-msgstr ""
+msgstr "Liste de définition"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:56
 msgid "Definition term"
-msgstr ""
+msgstr "Terme de définition"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:57
 msgid "Deleted text"
-msgstr ""
+msgstr "Texte supprimé"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:58
 msgid "Directionality"
-msgstr ""
+msgstr "Directionnalité"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:60
 msgid "Directionality (deprecated)"
-msgstr ""
+msgstr "Directionnalité (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:61
 msgid "Disabled"
-msgstr ""
+msgstr "Désactivé"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:62
 msgid "DIV container"
-msgstr ""
+msgstr "Conteneur DIV"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:63
 msgid "DIV Style container"
-msgstr ""
+msgstr "Conteneur de style DIV"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:64
 msgid "Document base"
-msgstr ""
+msgstr "Base du document"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:65
 msgid "Document body"
-msgstr ""
+msgstr "Corps du document"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:66
 msgid "Document head"
-msgstr ""
+msgstr "En-tête du document"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:67
 msgid "Element ID"
-msgstr ""
+msgstr "ID Élément"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:68
 msgid "Document title"
-msgstr ""
+msgstr "Titre du document"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:69
 msgid "Document type"
-msgstr ""
+msgstr "Type du document"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:70
 #: ../plugins/taglist/Latex.tags.xml.in.h:72
 msgid "Emphasis"
-msgstr ""
+msgstr "Accentuation"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:71
 msgid "Encode type"
-msgstr ""
+msgstr "Type de codage"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:73
 msgid "Font face (deprecated)"
-msgstr ""
+msgstr "Nom de la police (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:74
 msgid "For label"
-msgstr ""
+msgstr "Étiquette pour"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:75
 msgid "Forced line break"
-msgstr ""
+msgstr "Retour à la ligne forcé"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:76
 msgid "Form action handler"
-msgstr ""
+msgstr "Gestionnaire d'action du formulaire"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:77
 msgid "Form control group"
-msgstr ""
+msgstr "Groupe de contrôle du formulaire"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:78
 msgid "Form field label text"
-msgstr ""
+msgstr "Texte de l'étiquette du champ du formulaire"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:79
 msgid "Form input type"
-msgstr ""
+msgstr "Type d'entrée de formulaire"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:80
 msgid "Form input"
-msgstr ""
+msgstr "Entrée de formulaire"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:81
 msgid "Form method"
-msgstr ""
+msgstr "Méthode de formulaire"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:82
 msgid "Form"
-msgstr ""
+msgstr "Formulaire"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:83
 msgid "Forward link"
-msgstr ""
+msgstr "Lien inversé"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:84
 msgid "Frame render parts"
-msgstr ""
+msgstr "Partie de rendu de cadre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:85
 msgid "Frame source"
-msgstr ""
+msgstr "Source du cadre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:86
 msgid "Frame target"
-msgstr ""
+msgstr "Cible du cadre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:87
 msgid "Frame"
-msgstr ""
+msgstr "Cadre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:88
 msgid "Frame border"
-msgstr ""
+msgstr "Bord de cadre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:89
 msgid "Frameset columns"
-msgstr ""
+msgstr "Colonnes d'un ensemble de cadres"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:90
 msgid "Frameset rows"
-msgstr ""
+msgstr "Lignes d'un ensemble de cadres"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:91
 msgid "Frameset"
-msgstr ""
+msgstr "Ensemble de cadres"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:92
 msgid "Frame spacing"
-msgstr ""
+msgstr "Espacement de cadre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:93
 msgid "Generic embedded object"
-msgstr ""
+msgstr "Objet encapsulé générique"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:94
 msgid "Generic metainformation"
-msgstr ""
+msgstr "Méta-information générique"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:95
 msgid "Generic span"
-msgstr ""
+msgstr "Étalement générique"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:96
 msgid "Header cell IDs"
-msgstr ""
+msgstr "ID de cellule d'en-tête"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:97
 msgid "Heading 1"
-msgstr ""
+msgstr "Titre 1"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:98
 msgid "Heading 2"
-msgstr ""
+msgstr "Titre 2"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:99
 msgid "Heading 3"
-msgstr ""
+msgstr "Titre 3"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:100
 msgid "Heading 4"
-msgstr ""
+msgstr "Titre 4"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:101
 msgid "Heading 5"
-msgstr ""
+msgstr "Titre 5"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:102
 msgid "Heading 6"
-msgstr ""
+msgstr "Titre 6"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:103
 msgid "Height"
-msgstr ""
+msgstr "Hauteur"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:104
 msgid "Horizontal rule"
-msgstr ""
+msgstr "Règle horizontale"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:106
 msgid "Horizontal space (deprecated)"
-msgstr ""
+msgstr "Espace horizontal (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:107
 msgid "HREF URI"
-msgstr ""
+msgstr "URI HREF"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:108
 msgid "HTML root element"
-msgstr ""
+msgstr "Élément racine HTML"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:109
 msgid "HTTP header name"
-msgstr ""
+msgstr "Nom d'en-tête HTTP"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:110
 msgid "I18N BiDi override"
-msgstr ""
+msgstr "Remplacer la directionnalité de la langue"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:111
 msgid "Image map area"
-msgstr ""
+msgstr "Zone de l'image carte"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:112
 msgid "Image map name"
-msgstr ""
+msgstr "Nom de l'image carte"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:113
 msgid "Image map"
-msgstr ""
+msgstr "Image carte"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:114
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:115
 msgid "Inline frame"
-msgstr ""
+msgstr "Cadre en ligne"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:116
 msgid "Inserted text"
-msgstr ""
+msgstr "Texte inséré"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:117
 msgid "Instance definition"
-msgstr ""
+msgstr "Définition d'instance"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:118
 msgid "Italic text"
-msgstr ""
+msgstr "Texte italique"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:120
 msgid "Java applet (deprecated)"
-msgstr ""
+msgstr "Applet Java (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:121
 msgid "Label"
-msgstr ""
+msgstr "Étiquette"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:122
 msgid "Language code"
-msgstr ""
+msgstr "Code du language"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:123
 msgid "Large text style"
-msgstr ""
+msgstr "Style de texte grand"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:125
 msgid "Link color (deprecated)"
-msgstr ""
+msgstr "Couleur des liens (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:126
 msgid "List item"
-msgstr ""
+msgstr "Élément de liste"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:127
 msgid "List of MIME types for file upload"
-msgstr ""
+msgstr "Liste des types MIME pour les envois de fichiers"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:128
 msgid "List of supported character sets"
-msgstr ""
+msgstr "Liste des jeux de caractères pris en charge"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:129
 msgid "Local change to font"
-msgstr ""
+msgstr "Modification locale de la police"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:130
 msgid "Long description link"
-msgstr ""
+msgstr "Description longue de lien"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:131
 msgid "Long quotation"
-msgstr ""
+msgstr "Longue citation"
 
 #. Supported in XHTML 1.0 Frameset DTD only.
 #: ../plugins/taglist/HTML.tags.xml.in.h:133
 msgid "Margin pixel height"
-msgstr ""
+msgstr "Hauteur en pixel de la marge"
 
 #. Supported in XHTML 1.0 Frameset DTD only.
 #: ../plugins/taglist/HTML.tags.xml.in.h:135
 msgid "Margin pixel width"
-msgstr ""
+msgstr "Largeur en pixel de la marge"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:136
 msgid "Maximum length of text field"
-msgstr ""
+msgstr "Taille maximum du champ de texte"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:137
 msgid "Output media"
-msgstr ""
+msgstr "Média de sortie"
 
 #. Here I take some liberties: There's no mandatory attributes,
 #. but those are most common, and will likely be used.
 #: ../plugins/taglist/HTML.tags.xml.in.h:140
 msgid "Media-independent link"
-msgstr ""
+msgstr "Lien indépendant du média"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:142
 msgid "Menu list (deprecated)"
-msgstr ""
+msgstr "Liste de menu (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:143
 msgid "Multi-line text field"
-msgstr ""
+msgstr "Champ texte multi-lignes"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:144
 msgid "Multiple"
-msgstr ""
+msgstr "Multiple"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:145
 msgid "Name"
-msgstr ""
+msgstr "Nom"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:146
 msgid "Named property value"
-msgstr ""
+msgstr "Valeur de la propriété nommée"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:147
 msgid "No frames"
-msgstr ""
+msgstr "Aucun cadre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:148
 msgid "No resize"
-msgstr ""
+msgstr "Aucun redimensionnement"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:149
 msgid "No script"
-msgstr ""
+msgstr "Aucun script"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:151
 msgid "No shade (deprecated)"
-msgstr ""
+msgstr "Aucune ombre (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:152
 msgid "No URI"
-msgstr ""
+msgstr "Aucun URI"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:154
 msgid "No word wrap (deprecated)"
-msgstr ""
+msgstr "Aucune césure de mot (obsolète)"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:156
 msgid "Object applet file (deprecated)"
-msgstr ""
+msgstr "Fichier objet de l'applet (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:157
 msgid "Object data reference"
-msgstr ""
+msgstr "Référence des données d'objet"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:158
 msgid "Offset for alignment character"
-msgstr ""
+msgstr "Décalage pour l'alignement des caractères"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:159
 msgid "OnBlur event"
-msgstr ""
+msgstr "Événement OnBlur"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:160
 msgid "OnChange event"
-msgstr ""
+msgstr "Événement OnChange"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:161
 msgid "OnClick event"
-msgstr ""
+msgstr "Événement OnClick"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:162
 msgid "OnDblClick event"
-msgstr ""
+msgstr "Événement OnDblClick"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:163
 msgid "OnFocus event"
-msgstr ""
+msgstr "Événement OnFocus"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:164
 msgid "OnKeyDown event"
-msgstr ""
+msgstr "Événement OnKeyDown"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:165
 msgid "OnKeyPress event"
-msgstr ""
+msgstr "Événement OnKeyPress"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:166
 msgid "OnKeyUp event"
-msgstr ""
+msgstr "Événement OnKeyUp"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:167
 msgid "OnLoad event"
-msgstr ""
+msgstr "Événement OnLoad"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:168
 msgid "OnMouseDown event"
-msgstr ""
+msgstr "Événement OnMouseDown"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:169
 msgid "OnMouseMove event"
-msgstr ""
+msgstr "Événement OnMouseMove"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:170
 msgid "OnMouseOut event"
-msgstr ""
+msgstr "Événement OnMouseOut"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:171
 msgid "OnMouseOver event"
-msgstr ""
+msgstr "Événement OnMouseOver"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:172
 msgid "OnMouseUp event"
-msgstr ""
+msgstr "Événement OnMouseUp"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:173
 msgid "OnReset event"
-msgstr ""
+msgstr "Événement OnReset"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:174
 msgid "OnSelect event"
-msgstr ""
+msgstr "Événement OnSelect"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:175
 msgid "OnSubmit event"
-msgstr ""
+msgstr "Événement OnSubmit"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:176
 msgid "OnUnload event"
-msgstr ""
+msgstr "Événement OnUnLoad"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:177
 msgid "Option group"
-msgstr ""
+msgstr "Groupe d'options"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:178
 msgid "Option selector"
-msgstr ""
+msgstr "Sélecteur d'option"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:179
 msgid "Ordered list"
-msgstr ""
+msgstr "Liste ordonnée"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:180
 msgid "Paragraph class"
-msgstr ""
+msgstr "Classe de paragraphe"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:181
 msgid "Paragraph style"
-msgstr ""
+msgstr "Style de paragraphe"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:182
 msgid "Paragraph"
-msgstr ""
+msgstr "Paragraphe"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:183
 msgid "Preformatted text"
-msgstr ""
+msgstr "Texte préformaté"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:184
 msgid "Profile metainfo dictionary"
-msgstr ""
+msgstr "Dictionnaire de profils de métainfo"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:185
 msgid "Push button"
-msgstr ""
+msgstr "Bouton"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:186
 msgid "ReadOnly text and password"
-msgstr ""
+msgstr "Texte en lecture seule et mot de passe"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:188
 msgid "Reduced spacing (deprecated)"
-msgstr ""
+msgstr "Espacement réduit (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:189
 msgid "Reverse link"
-msgstr ""
+msgstr "Lien inverse"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:190
 msgid "Rows"
-msgstr ""
+msgstr "Lignes"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:191
 msgid "Rulings between rows and columns"
-msgstr ""
+msgstr "Largeur de trait entre les lignes et les colonnes"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:192
 msgid "Sample program output, scripts"
-msgstr ""
+msgstr "Sortie de programme d'exemple, scripts"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:193
 msgid "Scope covered by header cells"
-msgstr ""
+msgstr "Étendue couverte par les cellule d'en-tête"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:195
 msgid "Script language name"
-msgstr ""
+msgstr "Nom du langage de script"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:196
 msgid "Script statements"
-msgstr ""
+msgstr "Bloc de script"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:197
 msgid "Scrollbar"
-msgstr ""
+msgstr "Barre de défilement"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:198
 msgid "Selectable option"
-msgstr ""
+msgstr "Option sélectionnable"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:199
 msgid "Selected"
-msgstr ""
+msgstr "Sélectionné"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:200
 msgid "Server-side image map"
-msgstr ""
+msgstr "Carte image côté serveur"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:201
 msgid "Shape"
-msgstr ""
+msgstr "Forme"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:202
 msgid "Short inline quotation"
-msgstr ""
+msgstr "Courte citation en ligne"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:204
 msgid "Size (deprecated)"
-msgstr ""
+msgstr "Taille (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:205
 msgid "Small text style"
-msgstr ""
+msgstr "Style de texte petit"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:206
 msgid "Source"
-msgstr ""
+msgstr "Source"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:207
 msgid "Space-separated archive list"
-msgstr ""
+msgstr "Liste d'archives séparées par des espaces"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:208
 msgid "Spacing between cells"
-msgstr ""
+msgstr "Espacement entre les cellules"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:209
 msgid "Spacing within cells"
-msgstr ""
+msgstr "Espacement dans les cellules"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:210
 msgid "Span"
-msgstr ""
+msgstr "Extension"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:211
 msgid "Standby load message"
-msgstr ""
+msgstr "Message durant chargement"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:213
 msgid "Starting sequence number (deprecated)"
-msgstr ""
+msgstr "Nombre de début de séquence (obsolète)"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:215
 msgid "Strike-through text style (deprecated)"
-msgstr ""
+msgstr "Style de texte barré (obsolète)"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:217
 msgid "Strike-through text (deprecated)"
-msgstr ""
+msgstr "Texte barré (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:218
 msgid "Strong emphasis"
-msgstr ""
+msgstr "Emphase forte (gras)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:219
 msgid "Style info"
-msgstr ""
+msgstr "Information de style"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:220
 msgid "Subscript"
-msgstr ""
+msgstr "Indice"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:221
 msgid "Superscript"
-msgstr ""
+msgstr "Exposant"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:222
 msgid "Table body"
-msgstr ""
+msgstr "Corps de tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:223
 msgid "Table caption"
-msgstr ""
+msgstr "Légende du tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:224
 msgid "Table column group properties"
-msgstr ""
+msgstr "Propriétés du groupe de colonnes du tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:225
 msgid "Table column properties"
-msgstr ""
+msgstr "Propriétés de la colonne du tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:226
 msgid "Table data cell"
-msgstr ""
+msgstr "Cellule de donnée du tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:227
 msgid "Table footer"
-msgstr ""
+msgstr "Pied du tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:228
 msgid "Table header cell"
-msgstr ""
+msgstr "Cellule d'en-tête de tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:229
 msgid "Table header"
-msgstr ""
+msgstr "En-tête de tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:230
 msgid "Table row"
-msgstr ""
+msgstr "Ligne de tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:231
 msgid "Table summary"
-msgstr ""
+msgstr "Table des matières"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:232
 msgid "Table"
-msgstr ""
+msgstr "Tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:233
 msgid "Target - Blank"
-msgstr ""
+msgstr "Cible - Vide"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:234
 msgid "Target - Parent"
-msgstr ""
+msgstr "Cible - Parent"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:235
 msgid "Target - Self"
-msgstr ""
+msgstr "Cible - Lui-même"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:236
 msgid "Target - Top"
-msgstr ""
+msgstr "Cible - Au-dessus"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:237
 msgid "Teletype or monospace text style"
-msgstr ""
+msgstr "Style de texte téléscrupteur ou à espacement fixe"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:239
 msgid "Text color (deprecated)"
-msgstr ""
+msgstr "Couleur du texte (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:240
 msgid "Text entered by user"
-msgstr ""
+msgstr "Texte saisie par l'utilisateur"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:241
 msgid "Title"
-msgstr ""
+msgstr "Titre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:242
 msgid "Underlined text style"
-msgstr ""
+msgstr "Style de texte souligné"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:243
 msgid "Unordered list"
-msgstr ""
+msgstr "Liste non-ordonnée"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:244
 msgid "Use image map"
-msgstr ""
+msgstr "Utiliser une image carte"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:245
 msgid "Value interpretation"
-msgstr ""
+msgstr "Valeur d'interprétation"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:246
 msgid "Value"
-msgstr ""
+msgstr "Valeur"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:247
 msgid "Variable or program argument"
-msgstr ""
+msgstr "Variable ou paramètre de programme"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:248
 msgid "Vertical cell alignment"
-msgstr ""
+msgstr "Alignement des cellules verticales"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:250
 msgid "Vertical space (deprecated)"
-msgstr ""
+msgstr "Espace vertical (obsolète)"
 
 #. Deprecated since HTML 4.01, not supported in XHTML 1.0 Strict DTD.
 #: ../plugins/taglist/HTML.tags.xml.in.h:252
 msgid "Visited link color (deprecated)"
-msgstr ""
+msgstr "Couleur des liens visités (obsolète)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:253
 msgid "Width"
-msgstr ""
+msgstr "Largeur"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:254
 msgid "HTML - Tags"
-msgstr ""
+msgstr "HTML - Balises"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:255
 msgid "Above"
-msgstr ""
+msgstr "Au-dessus"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:256
 msgid "Applet class file code"
-msgstr ""
+msgstr "Code source de classe d'applet"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:257
 msgid "Array"
-msgstr ""
+msgstr "Tableau"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:258
 msgid "Background color"
-msgstr ""
+msgstr "Couleur d'arrière-plan"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:259
 msgid "Background texture tile"
-msgstr ""
+msgstr "Étirement de l'image en arrière-plan"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:260
 msgid "Base font"
-msgstr ""
+msgstr "Police standard"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:261
 msgid "Border color"
-msgstr ""
+msgstr "Couleur du bord"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:262
 msgid "Border"
-msgstr ""
+msgstr "Bordure"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:263
 msgid "Center"
-msgstr ""
+msgstr "Centrer"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:264
 msgid "Checked (state)"
-msgstr ""
+msgstr "Coché (état)"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:265
 msgid "Color of selected links"
-msgstr ""
+msgstr "Couleur des liens sélectionnés"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:266
 msgid "Content scheme"
-msgstr ""
+msgstr "Schéma du contenu"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:267
 msgid "Content type"
-msgstr ""
+msgstr "Type de contenu"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:268
 msgid "Direction"
-msgstr ""
+msgstr "Direction"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:269
 msgid "Directory list"
-msgstr ""
+msgstr "Liste des dossiers"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:270
 msgid "HTML version"
-msgstr ""
+msgstr "Version HTML"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:271
 msgid "Embedded object"
-msgstr ""
+msgstr "Objet embarqué"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:272
 msgid "Figure"
-msgstr ""
+msgstr "Illustration"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:273
 msgid "Font face"
-msgstr ""
+msgstr "Nom de la police"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:274
 msgid "Frameborder"
-msgstr ""
+msgstr "Bord de cadre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:275
 msgid "Framespacing"
-msgstr ""
+msgstr "Espacement de cadre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:276
 msgid "Heading"
-msgstr ""
+msgstr "Titre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:277
 msgid "Horizontal space"
-msgstr ""
+msgstr "Espace horizontal"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:278
 msgid "Image source"
-msgstr ""
+msgstr "Image source"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:279
 msgid "Inline layer"
-msgstr ""
+msgstr "Couche en ligne"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:280
 msgid "Java applet"
-msgstr ""
+msgstr "Applet Java"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:281
 msgid "Layer"
-msgstr ""
+msgstr "Couches"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:282
 msgid "Link color"
-msgstr ""
+msgstr "Couleur des liens"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:283
 msgid "Listing"
-msgstr ""
+msgstr "Listing"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:284
 msgid "Mail link"
-msgstr ""
+msgstr "Lien de messagerie"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:285
 msgid "Marquee"
-msgstr ""
+msgstr "Texte défilant"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:286
 msgid "Menu list"
-msgstr ""
+msgstr "Liste de menu"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:287
 msgid "Multicolumn"
-msgstr ""
+msgstr "Multi-colonne"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:288
 msgid "Next ID"
-msgstr ""
+msgstr "ID suivant"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:289
 msgid "No embedded objects"
-msgstr ""
+msgstr "Aucun objet encapsulé"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:290
 msgid "No layers"
-msgstr ""
+msgstr "Aucune couche"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:291
 msgid "No line break"
-msgstr ""
+msgstr "Aucune coupure de ligne"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:292
 msgid "No shade"
-msgstr ""
+msgstr "Aucune ombre"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:293
 msgid "No word wrap"
-msgstr ""
+msgstr "Aucune césure de mot"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:294
 msgid "Note"
-msgstr ""
+msgstr "Note"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:295
 msgid "Object applet file"
-msgstr ""
+msgstr "Fichier objet de l'applet"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:296
 msgid "Preformatted listing"
-msgstr ""
+msgstr "Liste préformatée"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:297
 msgid "Prompt message"
-msgstr ""
+msgstr "Message d'invite"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:298
 msgid "Quote"
-msgstr ""
+msgstr "Citation"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:299
 msgid "Range"
-msgstr ""
+msgstr "Intervalle"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:300
 msgid "Reduced spacing"
-msgstr ""
+msgstr "Espacement réduit"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:301
 msgid "Root"
-msgstr ""
+msgstr "Racine"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:302
 msgid "Single line prompt"
-msgstr ""
+msgstr "Invite sur une seule ligne"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:303
 msgid "Size"
-msgstr ""
+msgstr "Taille"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:304
 msgid "Soft line break"
-msgstr ""
+msgstr "Saut de ligne non restreint"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:305
 msgid "Sound"
-msgstr ""
+msgstr "Son"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:306
 msgid "Spacer"
-msgstr ""
+msgstr "Espacement"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:307
 msgid "Square root"
-msgstr ""
+msgstr "Racine carrée"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:308
 msgid "Starting sequence number"
-msgstr ""
+msgstr "Nombre de début de séquence"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:309
 msgid "Strike-through text style"
-msgstr ""
+msgstr "Style de texte barré"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:310
 msgid "Strike-through text"
-msgstr ""
+msgstr "Texte barré"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:311
 msgid "Tab order position"
-msgstr ""
+msgstr "Ordre de la position des onglets"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:312
 msgid "Text color"
-msgstr ""
+msgstr "Couleur du texte"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:313
 msgid "Text"
-msgstr ""
+msgstr "Texte"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:314
 msgid "Top margin in pixels"
-msgstr ""
+msgstr "Marge supérieure en pixels"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:315
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:316
 msgid "Vertical space"
-msgstr ""
+msgstr "Espace vertical"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:317
 msgid "Visited link color"
-msgstr ""
+msgstr "Couleur des liens visités"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:318
 msgid "HTML - Special Characters"
-msgstr ""
+msgstr "HTML - Caractères spéciaux"
 
 #: ../plugins/taglist/HTML.tags.xml.in.h:319
 msgid "Non-breaking space"
-msgstr ""
+msgstr "Espace insécable"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:1
 msgid "Latex - Tags"
-msgstr ""
+msgstr "Balises LaTeX"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:2
 msgid "Bibliography (cite)"
-msgstr ""
+msgstr "Bibliographie (cite)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:3
 msgid "Bibliography (item)"
-msgstr ""
+msgstr "Bibliographie (item)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:4
 msgid "Bibliography (shortcite)"
-msgstr ""
+msgstr "Bibliographie (shortcite)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:5
 msgid "Bibliography (thebibliography)"
-msgstr ""
+msgstr "Bibliographie (thebibliography)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:6
 msgid "Brackets ()"
-msgstr ""
+msgstr "Parenthèses ()"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:7
 msgid "Brackets []"
-msgstr ""
+msgstr "Crochets []"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:8
 msgid "Brackets {}"
-msgstr ""
+msgstr "Accolades {}"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:9
 msgid "Brackets <>"
-msgstr ""
+msgstr "Chevrons <>"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:10
 msgid "File input"
-msgstr ""
+msgstr "Fichier d'entrée"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:11
 msgid "Function cosine"
-msgstr ""
+msgstr "Fonction cosinus"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:12
 msgid "Function e^"
-msgstr ""
+msgstr "Fonction exposant"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:13
 msgid "Function exp"
-msgstr ""
+msgstr "Fonction exponentielle"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:14
 msgid "Function log"
-msgstr ""
+msgstr "Fonction logarithme"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:15
 msgid "Function log10"
-msgstr ""
+msgstr "Fonction logarithme décimal"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:16
 msgid "Function sine"
-msgstr ""
+msgstr "Fonction sinus"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:17
 msgid "Greek alpha"
-msgstr ""
+msgstr "Alpha grec"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:18
 msgid "Greek beta"
-msgstr ""
+msgstr "Bêta grec"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:19
 msgid "Greek epsilon"
-msgstr ""
+msgstr "Epsilon grec"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:20
 msgid "Greek gamma"
-msgstr ""
+msgstr "Gamma grec"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:21
 msgid "Greek lambda"
-msgstr ""
+msgstr "Lambda grec"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:22
 msgid "Greek rho"
-msgstr ""
+msgstr "Rho grec"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:23
 msgid "Greek tau"
-msgstr ""
+msgstr "Tau grec"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:24
 msgid "Header 0 (chapter)"
-msgstr ""
+msgstr "Titre 0 (chapitre)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:25
 msgid "Header 0 (chapter*)"
-msgstr ""
+msgstr "Titre 0 (chapitre*)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:26
 msgid "Header 1 (section)"
-msgstr ""
+msgstr "Titre 1 (section)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:27
 msgid "Header 1 (section*)"
-msgstr ""
+msgstr "Titre 1 (section*)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:28
 msgid "Header 2 (subsection)"
-msgstr ""
+msgstr "Titre 2 (sous-section)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:29
 msgid "Header 2 (subsection*)"
-msgstr ""
+msgstr "Titre 2 (sous-section*)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:30
 msgid "Header 3 (subsubsection)"
-msgstr ""
+msgstr "Titre 3 (sous-sous-section)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:31
 msgid "Header 3 (subsubsection*)"
-msgstr ""
+msgstr "Titre 3 (sous-sous-section*)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:32
 msgid "Header 4 (paragraph)"
-msgstr ""
+msgstr "Titre 4 (paragraphe)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:33
 msgid "Header appendix"
-msgstr ""
+msgstr "Annexe"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:34
 msgid "List description"
-msgstr ""
+msgstr "Liste de type description"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:35
 msgid "List enumerate"
-msgstr ""
+msgstr "Liste de type énumération"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:36
 msgid "List itemize"
-msgstr ""
+msgstr "Liste à puces"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:37
 msgid "Item with label"
-msgstr ""
+msgstr "Élément avec étiquette"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:38
 msgid "Item"
-msgstr ""
+msgstr "Élément"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:39
 msgid "Maths (display)"
-msgstr ""
+msgstr "Mode mathématique (hors-ligne)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:40
 msgid "Maths (inline)"
-msgstr ""
+msgstr "Mode mathématique (en-ligne)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:41
 msgid "Operator fraction"
-msgstr ""
+msgstr "Opérateur fraction"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:42
 msgid "Operator integral (display)"
-msgstr ""
+msgstr "Opérateur intégral (hors-ligne)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:43
 msgid "Operator integral (inline)"
-msgstr ""
+msgstr "Opérateur intégral (en-ligne)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:44
 msgid "Operator sum (display)"
-msgstr ""
+msgstr "Opérateur somme (hors-ligne)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:45
 msgid "Operator sum (inline)"
-msgstr ""
+msgstr "Opérateur somme (en-ligne)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:46
 msgid "Reference label"
-msgstr ""
+msgstr "Etiquette de la référence"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:47
 msgid "Reference ref"
-msgstr ""
+msgstr "Référence"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:48
 msgid "Symbol <<"
-msgstr ""
+msgstr "Symbole << (≪)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:49
 msgid "Symbol <="
-msgstr ""
+msgstr "Symbole <= (≤)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:50
 msgid "Symbol >="
-msgstr ""
+msgstr "Symbole >= (≥)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:51
 msgid "Symbol >>"
-msgstr ""
+msgstr "Symbole >>"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:52
 msgid "Symbol and"
-msgstr ""
+msgstr "Symbole et (∧)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:53
 msgid "Symbol const"
-msgstr ""
+msgstr "Symbole const"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:54
 msgid "Symbol d2-by-dt2-partial"
-msgstr ""
+msgstr "Symbole d2-by-dt2-partial"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:55
 msgid "Symbol dagger"
-msgstr ""
+msgstr "Symbole obèle (†)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:56
 msgid "Symbol d-by-dt"
-msgstr ""
+msgstr "Symbole d-by-dt"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:57
 msgid "Symbol d-by-dt-partial"
-msgstr ""
+msgstr "Symbole d-by-dt-partial"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:58
 msgid "Symbol equiv"
-msgstr ""
+msgstr "Symbole equiv (≡)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:59
 msgid "Symbol en-dash --"
-msgstr ""
+msgstr "Symbole tiret moyen --"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:60
 msgid "Symbol em-dash ---"
-msgstr ""
+msgstr "Symbole tiret long ---"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:61
 msgid "Symbol infinity"
-msgstr ""
+msgstr "Symbole infini (∞)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:62
 msgid "Symbol mathspace ,"
-msgstr ""
+msgstr "Symbole espace mathématique ,"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:63
 msgid "Symbol mathspace ."
-msgstr ""
+msgstr "Symbole espace mathématique ."
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:64
 msgid "Symbol mathspace _"
-msgstr ""
+msgstr "Symbole espace mathématique _"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:65
 msgid "Symbol mathspace __"
-msgstr ""
+msgstr "Symbole espace mathématique __"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:66
 msgid "Symbol simeq"
-msgstr ""
+msgstr "Symbole simeq (≃)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:67
 msgid "Symbol star"
-msgstr ""
+msgstr "Symbole étoile"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:68
 msgid "Typeface bold"
-msgstr ""
+msgstr "Gras (bold)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:69
 msgid "Typeface type"
-msgstr ""
+msgstr "Courrier (type)"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:70
 msgid "Typeface italic"
-msgstr ""
+msgstr "Italique"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:71
 msgid "Typeface slanted"
-msgstr ""
+msgstr "Penché"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:73
 msgid "Unbreakable text"
-msgstr ""
+msgstr "Texte insécable"
 
 #: ../plugins/taglist/Latex.tags.xml.in.h:74
 msgid "Footnote"
-msgstr ""
+msgstr "Note de bas de page"
 
 #: ../plugins/taglist/taglist.plugin.desktop.in.h:1
 msgid "Tag list"
-msgstr ""
+msgstr "Liste des balises"
 
 #: ../plugins/taglist/taglist.plugin.desktop.in.h:2
 msgid ""
 "Provides a method to easily insert commonly used tags/strings into a "
 "document without having to type them."
 msgstr ""
+"Fournit une méthode permettant d'insérer facilement dans un document des "
+"balises ou chaînes souvent utilisées sans avoir besoin de les écrire."
 
 #: ../plugins/taglist/xed-taglist-plugin-panel.c:605
 msgid "Select the group of tags you want to use"
-msgstr ""
+msgstr "Sélectionner le groupe de balises que vous souhaitez utiliser"
 
 #: ../plugins/taglist/xed-taglist-plugin-panel.c:624
 msgid "_Preview"
-msgstr ""
+msgstr "_Aperçu"
 
 #: ../plugins/taglist/xed-taglist-plugin-panel.c:700
 msgid "Available Tag Lists"
-msgstr ""
+msgstr "Liste de balises disponibles"
 
 #: ../plugins/taglist/xed-taglist-plugin-panel.c:703
 #: ../plugins/taglist/xed-taglist-plugin-panel.c:718
 #: ../plugins/taglist/xed-taglist-plugin.c:110
 msgid "Tags"
-msgstr ""
+msgstr "Balises"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:1
 msgid "XSLT - Elements"
-msgstr ""
+msgstr "XSLT - Éléments"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:2
 msgid "XSLT - Functions"
-msgstr ""
+msgstr "XSLT - Fonctions"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:3
 msgid "XSLT - Axes"
-msgstr ""
+msgstr "XSLT - Axes"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:4
 msgid "ancestor"
-msgstr ""
+msgstr "ancestor"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:5
 msgid "ancestor-or-self"
-msgstr ""
+msgstr "ancestor-or-self"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:6
 msgid "attribute"
-msgstr ""
+msgstr "attribute"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:7
 msgid "child"
-msgstr ""
+msgstr "child"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:8
 msgid "descendant"
-msgstr ""
+msgstr "descendant"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:9
 msgid "descendant-or-self"
-msgstr ""
+msgstr "descendant-or-self"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:10
 msgid "following"
-msgstr ""
+msgstr "following"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:11
 msgid "following-sibling"
-msgstr ""
+msgstr "following-sibling"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:12
 msgid "namespace"
-msgstr ""
+msgstr "namespace"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:13
 msgid "parent"
-msgstr ""
+msgstr "parent"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:14
 msgid "preceding"
-msgstr ""
+msgstr "preceding"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:15
 msgid "preceding-sibling"
-msgstr ""
+msgstr "preceding-sibling"
 
 #: ../plugins/taglist/XSLT.tags.xml.in.h:16
 msgid "self"
-msgstr ""
+msgstr "self"
 
 #: ../plugins/taglist/XUL.tags.xml.in.h:1
 msgid "XUL - Tags"
-msgstr ""
+msgstr "XUL - Balises"
 
 #: ../plugins/textsize/textsize.plugin.desktop.in.h:1
 msgid "Text Size"
-msgstr ""
+msgstr "Taille du texte"
 
 #: ../plugins/textsize/textsize.plugin.desktop.in.h:2
 msgid "Allow controlling the zoom levels of the text"
-msgstr ""
+msgstr "Permettre le contrôle du niveau de zoom du texte"
 
 #: ../plugins/textsize/textsize/__init__.py:123
 msgid "_Larger Text"
-msgstr ""
+msgstr "A_grandir le texte"
 
 #: ../plugins/textsize/textsize/__init__.py:126
 msgid "S_maller Text"
-msgstr ""
+msgstr "Ré_duire le texte"
 
 #: ../plugins/textsize/textsize/__init__.py:129
 msgid "_Normal size"
-msgstr ""
+msgstr "Taille _normale"
 
 #: ../plugins/time/org.x.editor.plugins.time.gschema.xml.in.h:1
 msgid "Prompt type"
-msgstr ""
+msgstr "Type d'invite"
 
 #: ../plugins/time/org.x.editor.plugins.time.gschema.xml.in.h:2
 msgid "Selected format"
-msgstr ""
+msgstr "Format sélectionné"
 
 #: ../plugins/time/org.x.editor.plugins.time.gschema.xml.in.h:3
 msgid "Custom format"
-msgstr ""
+msgstr "Format personnalisé"
 
 #: ../plugins/time/time.plugin.desktop.in.h:1
 msgid "Insert Date/Time"
-msgstr ""
+msgstr "Insérer la date et l'heure"
 
 #: ../plugins/time/time.plugin.desktop.in.h:2
 msgid "Inserts current date and time at the cursor position."
-msgstr ""
+msgstr "Insérer la date et l'heure actuelle à l'emplacement du curseur."
 
 #: ../plugins/time/xed-time-dialog.ui.h:1
 msgid "Insert Date and Time"
-msgstr ""
+msgstr "Insérer la date et l'heure"
 
 #: ../plugins/time/xed-time-dialog.ui.h:2
 msgid "_Insert"
-msgstr ""
+msgstr "_Insérer"
 
 #: ../plugins/time/xed-time-dialog.ui.h:3
 #: ../plugins/time/xed-time-setup-dialog.ui.h:5
 msgid "Use the _selected format"
-msgstr ""
+msgstr "Utiliser le format _sélectionné"
 
 #: ../plugins/time/xed-time-dialog.ui.h:5
 #: ../plugins/time/xed-time-setup-dialog.ui.h:6
 msgid "_Use custom format"
-msgstr ""
+msgstr "_Utiliser un format personnalisé"
 
 #. Translators: Use the more common date format in your locale
 #: ../plugins/time/xed-time-dialog.ui.h:7
 #: ../plugins/time/xed-time-setup-dialog.ui.h:9
 #, no-c-format
 msgid "%d/%m/%Y %H:%M:%S"
-msgstr ""
+msgstr "%d/%m/%Y %H:%M:%S"
 
 #. Translators: This example should follow the date format defined in the entry above
 #: ../plugins/time/xed-time-dialog.ui.h:8
 #: ../plugins/time/xed-time-setup-dialog.ui.h:11
 msgid "01/11/2009 17:52:00"
-msgstr ""
+msgstr "01/11/2009 17:52:00"
 
 #: ../plugins/time/xed-time-plugin.c:176
 msgid "In_sert Date and Time..."
-msgstr ""
+msgstr "Insérer la _date et l'heure..."
 
 #: ../plugins/time/xed-time-plugin.c:178
 msgid "Insert current date and time at the cursor position"
-msgstr ""
+msgstr "Insérer la date et l'heure actuelle à l'emplacement du curseur"
 
 #: ../plugins/time/xed-time-plugin.c:454
 msgid "Available formats"
-msgstr ""
+msgstr "Formats disponibles"
 
 #: ../plugins/time/xed-time-setup-dialog.ui.h:1
 msgid "Configure date/time plugin"
-msgstr ""
+msgstr "Configurer le greffon d'insertion de date et d'heure"
 
 #: ../plugins/time/xed-time-setup-dialog.ui.h:2
 msgid "When inserting date/time..."
-msgstr ""
+msgstr "Lors de l'insertion de la date et de l'heure..."
 
 #: ../plugins/time/xed-time-setup-dialog.ui.h:4
 msgid "_Prompt for a format"
-msgstr ""
+msgstr "_Demander un format"
 
 #: ../plugins/trailsave/trailsave.plugin.desktop.in.h:1
 msgid "Save Without Trailing Spaces"
-msgstr ""
+msgstr "Enregistrer (supprimer les espaces de fin de ligne)"
 
 #: ../plugins/trailsave/trailsave.plugin.desktop.in.h:2
 msgid "Removes trailing spaces from lines before saving."
-msgstr ""
+msgstr "Supprime les espaces en fin de ligne avant d'enregistrer."
 
 #: ../plugins/wordcompletion/xed-wordcompletion-configure.ui.h:1
 msgid "Word Completion"
-msgstr ""
+msgstr "Complétion des mots"
 
 #: ../plugins/wordcompletion/xed-wordcompletion-configure.ui.h:2
 msgid "Use Ctrl+Space to manually trigger word completion."
-msgstr ""
+msgstr "Utilisez Ctrl+Espace pour activer manuellement la complétion de mots."
 
 #: ../plugins/wordcompletion/xed-wordcompletion-configure.ui.h:3
 msgid "Automatic completion"
-msgstr ""
+msgstr "Complétion automatique"
 
 #: ../plugins/wordcompletion/xed-wordcompletion-configure.ui.h:4
 msgid "Minimum word size for auto-completion"
-msgstr ""
+msgstr "Taille de mot minimum pour la complétion automatique"
 
 #: ../plugins/wordcompletion/xed-wordcompletion-plugin.c:214
 msgid "Word completion"
-msgstr ""
+msgstr "Complétion de mots"

--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -7,20 +7,16 @@
 
 
 
-
 ========== am.po ==========
-# Translations into the Amharic Language.
+# Amharic translation of xed.
 # Copyright (C) 2002 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
 # Ge'ez Frontier Foundation <locales@geez.org>, 2002.
-#
-#
-
 
 
 
 ========== ar.po ==========
-# translation of xed.HEAD.po to Arabic
+# Arabic translation of xed.
 # Isam Bayazidi <bayazidi@arabeyes.org>, 2002.#. Translator credits.
 # Sayed Jaffer Al-Mosawi <mosawi@arabeyes.org>, 2002.
 # Arafat Medini <lumina@silverpen.de>, 2002,2003.
@@ -36,47 +32,36 @@
 
 
 
-
 ========== as.po ==========
-# translation of as.po to Assamese
+# Assamese translation of xed.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-#
+# This file is distributed under the same license as the xed package.
 # Amitakhya Phukan <aphukan@redhat.com>, 2008.
 # Amitakhya Phukan <amitakhya@svn.gnome.org>, 2008.
 # Amitakhya Phukan <aphukan@fedoraproject.org>, 2009.
 
 
 
-
 ========== ast.po ==========
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# translation of xed.po to Asturian
-# Asturian translation for xed
+# Asturian translation for xed.
 # Copyright (c) 2007 Rosetta Contributors and Canonical Ltd 2007
 # This file is distributed under the same license as the xed package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2007.
 # Astur <astur@softastur.org>, 2007.
 # Xandru Armesto <xandru@softastur.org>, 2010.
 
 
 
-
 ========== az.po ==========
-# translation of xed.HEAD.az.po to Azerbaijani
-# translation of xed.HEAD.po to Azerbaijani Turkish
+# Azerbaijani translation of xed.
 # Copyright (C) 1999-2000,2003, 2004 Free Software Foundation, Inc.
 # Vasif Ismailoglu MD <azerb_linux@hotmail.com>,2000-2001 .
 # Mətin Əmirov <metin@karegen.com>, 2003, 2004.
 # Metin Amiroff <metin@karegen.com>, 2004.
-#
-
 
 
 
 ========== be.po ==========
+# Belarusian translation of xed.
 # Беларускі пераклад xed.HEAD.
 # Copyright (C) 1999, 2000, 2001, 2002, 2003, 2004 Free Software Foundation, Inc.
 # Vital Khilko <dojlid@mova.org>, 2002, 2003.
@@ -85,19 +70,17 @@
 
 
 
-
 ========== be@latin.po ==========
+# Belarusian Latin translation of xed.
 # Biełaruski pierakład xed.
 # Copyright (C) 2007 THE xed's COPYRIGHT HOLDER
 # This file is distributed under the same license as the xed package.
 # Alaksandar Navicki <zolak@lacinka.org>, 2006. Łacinka.org
-#
-
 
 
 
 ========== bg.po ==========
-# Bulgarian translation of xed po-file.
+# Bulgarian translation of xed.
 # Copyright (C) 2002, 2003, 2004, 2005, 2006 Free Software Foundation, Inc.
 # Copyright (C) 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
@@ -107,16 +90,13 @@
 # Alexander Shopov <ash@kambanaria.org>, 2006, 2007, 2009.
 # Yavor Doganov <yavor@gnu.org>, 2008.
 # Krasimir Chonov <mk2616@abv.bg>, 2010.
-#
-
 
 
 
 ========== bn.po ==========
-# Bengali translation of Xed.
+# Bengali translation of xed.
 # Copyright (C) 2003 Free Software Foundation
 # This file is distributed under the same license as the xed package.
-#
 # Santanu Chatterjee, 2003.
 # Runa Bhattacharjee <runa@bengalinux.com>, 2005.
 # Runa Bhattacharjee <runabh@gmail.com>, 2006.
@@ -126,17 +106,13 @@
 # Sadia Afroz <sadia@ankur.org.bd>, 2010.
 # Israt Jahan <israt@ankur.org.bd>, 2010.
 # Sadia Afroz <sadia@ankur.org.bd>, 2010.
-#
-
 
 
 
 ========== bn_IN.po ==========
-# translation of bn_IN.po to Bengali INDIA
 # Bengali India translation of xed.
 # Copyright (C) 2003 Free Software Foundation
 # This file is distributed under the same license as the xed package.
-#
 # Santanu Chatterjee, 2003.
 # Runa Bhattacharjee <runa@bengalinux.com>, 2005.
 # Runa Bhattacharjee <runabh@gmail.com>, 2006.
@@ -145,63 +121,59 @@
 
 
 
-
 ========== br.po ==========
-# Breton translation for Xed
-# # Copyright (c) 2008 Rosetta Contributors and Canonical Ltd 2008
+# Breton translation of xed.
+# Copyright (c) 2008 Rosetta Contributors and Canonical Ltd 2008
 # This file is distributed under the same license as the xed package.
-#
 # Giulia Fraboulet <djoulia@gmail.com>, 2006.
-#
-
 
 
 
 ========== bs.po ==========
-# translation of xed.HEAD.bs.po to Bosnian
-# translation of xed.HEAD.po to Bosnian
-# This file is distributed under the same license as the PACKAGE package.
+# Bosnian translation of xed.
+# This file is distributed under the same license as the xed package.
 # Copyright (C) 2004 THE PACKAGE'S COPYRIGHT HOLDER.
 # Kenan Hadžiavdić <kenan@bgnett.no>, 2004.
-#
-
 
 
 
 ========== ca.po ==========
-# xed translation to Catalan.
-# Copyright © 2000-2007, Free Software Foundation, Inc.
+# Catalan translation of xed.
+# Copyright (C) 2000-2007, Free Software Foundation, Inc.
 # Quico Llach <quico@softcatala.org>, 2000, 2001, 2002.
 # Jordi Mallach <jordi@sindominio.net>, 2002, 2003, 2004.
-# Jordi Mas i Hernàndez <jmas@softcatala.org>, 2003. 
+# Jordi Mas i Hernàndez <jmas@softcatala.org>, 2003.
 # Aleix Badia i Bosch <abadia@ica.es>, 2004.
 # Josep Puigdemont <josep.puigdemont@gmail.com>, 2005, 2006, 2007.
 # Gil Forcada <gilforcada@guifi.net>, 2008, 2009, 2010.
-#
-
 
 
 
 ========== ca@valencia.po ==========
-# xed translation to Catalan.
-# Copyright © 2000-2007, Free Software Foundation, Inc.
+# Catalan (Valencia) translation of xed.
+# Copyright (C) 2000-2007, Free Software Foundation, Inc.
 # Quico Llach <quico@softcatala.org>, 2000, 2001, 2002.
 # Jordi Mallach <jordi@sindominio.net>, 2002, 2003, 2004.
-# Jordi Mas i Hernàndez <jmas@softcatala.org>, 2003. 
+# Jordi Mas i Hernàndez <jmas@softcatala.org>, 2003.
 # Aleix Badia i Bosch <abadia@ica.es>, 2004.
 # Josep Puigdemont <josep.puigdemont@gmail.com>, 2005, 2006, 2007.
 # Gil Forcada <gilforcada@guifi.net>, 2008, 2009, 2010.
-#
 
+
+
+========== cmn.po ==========
+# Chinese (Mandarin) translation of xed.
+# Copyright (C) 2013 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
+# Wei-Lun Chao <bluebat@member.fsf.org>, 2013
 
 
 
 ========== crh.po ==========
-# Qırımtatarca xed.
+# Qırımtatarca translation of xed.
+# Copyright (C) 2009, 2010
 # This file is distributed under the same license as the xed package.
-#
 # Reşat SABIQ <tilde.birlik@gmail.com>, 2009, 2010.
-
 
 
 
@@ -225,9 +197,8 @@
 
 
 
-
 ========== cy.po ==========
-# xed yn Gymraeg (in Welsh).
+# Welsh translation of xed.
 # This file is distributed under the same license as the xed package.
 # Dafydd Harries <daf@muse.19inch.net>, 2003, 2004.
 # Rhys Jones <rhys@sucs.org>, 2004-2006.
@@ -245,23 +216,17 @@
 # rhys:
 # Benywaidd yw 'ffeil' fel arfer. Wedi ceisio cysoni hyn yn y ffeil hon :)
 # Newid 'arbed' i 'cadw'.
-#
-
 
 
 
 ========== da.po ==========
-# Danish translations of xed.
+# Danish translation of xed.
 # Copyright (C) 1999-2010 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
-#
 # Husk at tilføje dig i credit-listen (besked id "translator_credits")
-#
 # Konventioner:
-#
 #   plugin -> udvidelsesmodul
 #   snippet -> tekststump
-#
 # Birger Langkjer <birger.langkjer@image.dk>, 1999.
 # Kenneth Christiansen <kenneth@gnome.org>, 1999, 2000.
 # Keld Simonsen <keld@dkuug.dk>, 2000, 01.
@@ -271,13 +236,11 @@
 # Kenneth Nielsen <k.nielsen81@gmail.com>, 2006-2007, 2009.
 # M.P. Rommedahl <lhademmor@gmail.com>, 2008
 # Ask Hjorth Larsen <asklarsen@gmail.com>, 2007, 09, 10.
-#
-
 
 
 
 ========== de.po ==========
-# German xed translation.
+# German translation of xed.
 # Copyright (C) 1999-2005 Free Software Foundation, Inc.
 # Matthias Warkus <mawarkus@gnome.org>, 1999-2001.
 # Manuel Borchers <webmaster@matronix.de>, 2002.
@@ -288,22 +251,18 @@
 # Andre Klapper <ak-47@gmx.net>, 2008, 2009.
 # Mario Blättermann <mariobl@gnome.org>, 2009, 2010.
 # Christian Kirbach <Christian.Kirbach@googlemail.com>, 2008-2010.
-#
-
 
 
 
 ========== dz.po ==========
-# Dzongkha translation of xed
+# Dzongkha translation of xed.
 # Copyright @ 2006 Free Software Foundation, Inc.
 # Mindu Dorji.
-#
-
 
 
 
 ========== el.po ==========
-# Translation of Xed to Greek
+# Greek translation of xed.
 # Copyright (C) 2000 ~ 2010, Free Software Foundation, Inc.
 #
 # spyros:
@@ -336,55 +295,55 @@
 
 
 
-
-========== en@shaw.po ==========
-# Shavian translation..
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# Thomas Thurman <tthurman@gnome.org>, 2009.
-#
-
+========== en_AU.po ==========
+# English (Australia) translation of xed.
+# Copyright (C) 2012 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same licence as the xed package.
+# Michael Findlay <keltoiboy@gmail.com>, 2012-2014
+# Martin Bertrand <xed@mbertrand.ca>, 2021
 
 
 
 ========== en_CA.po ==========
-# English/Canada translation of xed.
+# English (Canada) translation of xed.
 # Copyright (C) 2004-2006 Adam Weinberger and the MATE Foundation
 # This file is distributed under the same licence as the xed package.
 # Adam Weinberger <adamw@gnome.org>, 2004, 2005, 2006.
-#
-#
-
+# Martin Bertrand <xed@mbertrand.ca>, 2021
 
 
 
 ========== en_GB.po ==========
-# English (British) translation.
+# English (British) translation of xed.
 # Copyright (C) 2004 THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the xed package.
 # Gareth Owen <gowen72@yahoo.com>, 2004.
 # Philip Withnall <philip@tecnocode.co.uk>, 2009–2010.
 # Bruce Cowan <bcowan@fastmail.co.uk>, 2010.
+# Martin Bertrand <xed@mbertrand.ca>, 2021
 
+
+
+========== en@shaw.po ==========
+# Shavian translation of xed.
+# Copyright (C) 2009 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
+# Thomas Thurman <tthurman@gnome.org>, 2009.
 
 
 
 ========== eo.po ==========
-# Esperanto translation for xed
+# Esperanto translation of xed.
 # Copyright (c) (c) 2006 Canonical Ltd, and Rosetta Contributors 2006
 # This file is distributed under the same license as the xed package
 # Joop Eggen <joop_eggen@yahoo.de>, 2006.
-#
-
 
 
 
 ========== es.po ==========
-# translation of xed.mate-2-30.po to Español
-# translation of xed to spanish
-# Copyright © 1999-2003, 2006, 2007, 2008 Free Software Foundation, Inc.
+# Spanish translation of xed.
+# Copyright (C) 1999-2003, 2006, 2007, 2008 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
-#
 # Pablo Saratxaga <srtxg@chanae.alphanet.ch>, 1999-2000.
 # Carlos Perelló Marín <carlos@mate-db.org>, 2000-2001.
 # Chema Celorio <chema@celorio.com>, 2000.
@@ -395,37 +354,28 @@
 # Juanje Ojeda Croissier <jojeda@emergya.es>, 2008.
 # Leandro Machacón <leandroman@gemail.com>, 2010.
 # Jorge González <jorgegonz@svn.gnome.org>, 2007, 2008, 2009, 2010.
-#
-
 
 
 
 ========== et.po ==========
-# Xed'i eesti keele tõlge.
-# Estonian translation of Xed.
-#
+# Estonian translation of xed.
 # Copyright (C) 2002, 2003, 2005, 2006 Free Software Foundation, Inc.
 # Copyright (C) 2007-2010 The MATE Project.
 # This file is distributed under the same license as the xed package.
-#
 # Ilmar Kerm <ikerm hot ee>, 2002.
 # Tõivo Leedjärv <toivo linux ee>, 2002, 2003.
 # Priit Laes <plaes plaes org>, 2005, 2009.
 # Ivar Smolin <okul linux ee>, 2005-2010.
 # Mattias Põldaru <mahfiaz gmail com>, 2009-2010.
-#
-
 
 
 
 ========== eu.po ==========
-# translation of eu.po to Basque
+# Basque translation of xed.
 # Copyright (C) 2001, 2004, 2005, 2006, 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
-#
 # Hizkuntza Politikarako Sailburuordetza <hizpol@ej-gv.es>, 2004.
 # Iñaki Larrañaga Murgoitio <dooteo@euskalgnu.org>, 2004, 2005, 2006, 2007, 2008, 2009, 2010.
 # Iñaki Larrañaga Murgoitio <dooteo@zundan.com>, 2007, 2008.
-
 
 
 
@@ -436,13 +386,11 @@
 # Roozbeh Pournader <roozbeh@farsiweb.info>, 2003, 2005.
 # Meelad Zakaria <meelad@farsiweb.info>, 2005.
 # Elnaz Sarbar <elnaz@farsiweb.info>, 2005.
-#
-
 
 
 
 ========== fi.po ==========
-# xed Finnish Translation
+# Finnish translation of xed.
 # Suomennos: http://www.mate.fi/
 # Copyright (C) 1999-2010 Free Software Foundation Inc.
 # Jarkko Ranta <jjranta@cc.joensuu.fi>, 2000-2004.
@@ -451,16 +399,13 @@
 # Ilkka Tuohela <hile@iki.fi>, 2005-2009.
 # Tommi Vainikainen <thv@iki.fi>, 2009-2010.
 # Jiri Grönroos <jiri.gronroos.iki.fi>, 2010.
-#
-
 
 
 
 ========== fr.po ==========
 # French translation of xed.
-# Copyright (C) 1998-2010 Free Software Foundation, Inc.
+# Copyright (C) 1998-2021 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
-#
 # Vincent Renardias <vincent@ldsol.com>, 1998-1999.
 # Joaquim Fellmann <joaquim@hrnet.fr>, 2000.
 # Christophe Merlet <redfox@redfoxcenter.org>, 2000-2005.
@@ -479,29 +424,32 @@
 # Claude Paroz <claude@2xlibre.net>, 2007-2010.
 # Bruno Brouard <annoa.b@gmail.com>, 2008.
 # Yannick Tailliez <ytdispatch-libre@yahoo.com>, 2008.
-#
+# Martin Bertrand <xed@mbertrand.ca>, 2021
 
+
+
+========== fr_CA.po ==========
+# French Canadian translation of xed.
+# Copyright (C) 2021 Free Software Foundation, Inc.
+# This file is distributed under the same license as the xed package.
+# Martin Bertrand <xed@mbertrand.ca>, 2021
 
 
 
 ========== ga.po ==========
-# Irish translations for xed package.
+# Irish translation of xed.
 # Copyright (C) 2000-2009 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
 # Alastair McKinstry <mckinstry@computer.org>, 2000.
 # Paul Duffy <dubhthach@frink.nuigalway.ie>, 2003.
 # Alan Horkan <horkan@maths.tcd.ie>, 2005.
 # Seán de Búrca <leftmostcat@gmail.com>, 2007-2009.
-#
-
 
 
 
 ========== gl.po ==========
-# translation of xed-master-po-gl-116402.merged.po to Galician
 # Galician translation of xed.
 # Copyright (C) 1999-2001, 2005, 2006, 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
-#
 # Ruben Lopez Gomez <ryu@mundivia.es>, 1999.
 # Manuel A. FernÃ¡ndez Montecelo <manuel@sindominio.net>, 2001.
 # Ignacio Casal Quinteiro <nacho.resa@gmail.com>, 2005, 2006.
@@ -516,34 +464,28 @@
 
 
 
-
 ========== gu.po ==========
-# translation of xed.master.gu.po to Gujarati
+# Gujarati translation of xed.
 # Ankit Patel <ankit644@yahoo.com>, 2005, 2006.
 # Ankit Patel <ankit@redhat.com>, 2007, 2008.
 # Sweta Kothari <swkothar@redhat.com>, 2008, 2009.
 
 
 
-
 ========== he.po ==========
-# translation of xed.HEAD.he.po to Hebrew
-# translation of xed.HEAD.po to Hebrew
-# This file is distributed under the same license as the PACKAGE package.
+# Hebrew translation of xed.
+# This file is distributed under the same license as the xed package.
 # Copyright (C) 2005 THE PACKAGE'S COPYRIGHT HOLDER.
 # Meir Kriheli <meirkr@mksoft.co.il>, 2003.
 # Gil 'Dolfin' Osher <dolfin@rpg.org.il>, 2003.
 # Gil Osher <dolfin@rpg.org.il>, 2004.
-#
-
 
 
 
 ========== hi.po ==========
-# translation of xed.master.po to Hindi
-# This file is distributed under the same license as the PACKAGE package.
+# Hindi translation of xed.
+# This file is distributed under the same license as the xed package.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER.
-#
 # G Karunakar <karunakar@freedomink.org>, 2003.
 # Ravishankar Shrivastava <raviratlami@yahoo.com>, 2004.
 # Rajesh Ranjan <rranjan@redhat.com>, 2005, 2006, 2007, 2009.
@@ -551,19 +493,16 @@
 
 
 
-
 ========== hr.po ==========
-# Translation of xed to Croatiann
+# Croatiann translation of xed.
 # Copyright (C) Croatiann team
 # Translators: Automatski Prijevod <>,Bozo Juretic <bjuretic@srce.hr>,Danijel Studen <dstuden@vuka.hr>,Denis Lackovic <delacko@fly.srk.fer.hr>,Mato Kutlić <mate@iskraemeco.hr>,pr pr <delacko@192.168.0.1>,Robert Sedak <robert.sedak@sk.t-com.hr>,Vlatko Kosturjak <kost@linux.hr>,
-
 
 
 
 ========== hu.po ==========
 # Hungarian translation of xed.
 # Copyright (C) 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
-#
 # Szabolcs Ban <shooby at mate dot hu>, 2000.
 # Emese Kovacs <emese at mate dot hu>, 2000, 2001.
 # Peter Doma <zelin at pointernet dot hu>, 2002.
@@ -575,14 +514,19 @@
 
 
 
-
 ========== hy.po ==========
-# Xed armenian translation
+# Armenian translation of xed.
 # Copyright (C) 2006 Norayr Chilingaryan
 # This file is distributed under the same license as the xed package.
 # Norayr Chilingaryan <norik@freenet.am>, 2006.
-#
 
+
+
+========== ia.po ==========
+Interlingua translation of xed.
+# Copyright (C) 2020 THE xed'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
+# karm <melo@carmu.com>, 2020
 
 
 
@@ -592,38 +536,39 @@
 # This file is distributed under the same license as the xed package.
 # Mohammad DAMT <mdamt@bisnisweb.com>
 # Ahmad Riza H Nst <ari@160c.afraid.org>, 20040508.
-#
-#
 
+
+
+========== ie.po ==========
+# Interlingue translation of xed.
+# Copyright (C) 2019 THE xed'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
+# Silvara <Unknown>
 
 
 
 ========== is.po ==========
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-
+# Icelandic translation of xed.
+# Copyright (C) 2020 THE xed'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
+# Sveinn í Felli <sv1@fellsnet.is>, 2020
 
 
 
 ========== it.po ==========
-# Italian translation of xed
+# Italian translation of xed.
 # Copyright (C) 1998-2008, 2009, 2010 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
 # Paolo Maggi <maggi@athena.polito.it> 2002
 # Giuseppe <quiquoqua@pn.itnet.it>, 1998.
 # Alessio Frusciante <algol@firenze.linux.it>, 2002.
 # Roberto Rosselli Del Turco <rosselli@ling.unipi.it>, 2003-2005.
-#
 # Milo Casagrande <milo@ubuntu.com> 2005, 2006, 2007, 2008, 2009, 2010.
 
 
 
-
 ========== ja.po ==========
-# xed ja.po.
+# Japanese translation of xed.
 # Copyright (C) 1999,2000,2002-2010 Free Software Foundation, Inc.
 # Akira Higuchi <a-higuti@math.sci.hokudai.ac.jp>, 1999
 # Yuusuke Tahara <tahara@gnome.gr.jp>
@@ -633,46 +578,45 @@
 # Takeshi AIHANA <takeshi.aihana@gmail.com>, 2003-2009.
 # Satoru SATOH <ss@gnome.gr.jp>, 2006.
 # Hideki Yamane (Debian-JP) <henrich@debian.or.jp>, 2009.
-#
-
 
 
 
 ========== ka.po ==========
-# translation of xed.po to Georgian
+# Georgian translation of xed.
 # Copyright (C) 2006 THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-#
+# This file is distributed under the same license as the xed package.
 # Vladimer Sichinava <alinux@siena.linux.it>, 2006.
 # Alexander Didebulidze <didebuli@in.tum.de>, 2006.
 
 
 
+========== kab.po ==========
+# Kabyle translation of xed.
+# Copyright (C) 2021 xed's COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
+# Yacine Bouklif <yacinebouklif@gmail.com>
+
+
 
 ========== kk.po ==========
-# Kazakh translation for xed.
+# Kazakh translation of xed.
 # Copyright (C) 2010 xed's COPYRIGHT HOLDER
 # This file is distributed under the same license as the xed package.
 # Baurzhan Muftakhidinov <baurthefirst@gmail.com>, 2010.
-#
-
 
 
 
 ========== kn.po ==========
-# translation of xed.master.kn.po to Kannada
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-#
+# Kannada translation of xed.
+# Copyright (C) 2007, 2008, 2009, 2010 xed's COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
 # Shankar Prasad <svenkate@redhat.com>, 2007, 2008, 2009, 2010.
 
 
 
-
 ========== ko.po ==========
-# xed ko.po
+# Korean translation of xed.
 # This file is distributed under the same license as the xed package.
-#
 # Sung-Hyun Nam <namsh@lgic.co.kr>, 1998
 # Chideok Hwang <hwang@mizi.co.kr>, 2000, 2001
 # Young-Ho, Cha <ganadist@chollian.net>, 2000, 2002, 2007
@@ -684,37 +628,35 @@
 # - 이 프로그램의 이름인 xed는 "지에디트"로 음역
 #   - 오류 메시지에서 xed가 주어가 되는 경우가 많은데 이 경우 뜻이
 #     통하는 경우 생략한다. "지에디트가 ..." 식으로 번역하지 않는다.
-#
-
 
 
 
 ========== ku.po ==========
-# translation of xed.HEAD.po to Kurdish
-# translation of xed.HEAD.pot to Kurdish
-# This file is distributed under the same license as the PACKAGE package.
+# Kurdish translation of xed.
+# This file is distributed under the same license as the xed package.
 # Copyright (C) 2005 THE PACKAGE'S COPYRIGHT HOLDER.
 # Erdal Ronahi <erdal.ronahi@gmail.com>, 2005.
-#
 
+
+
+========== ky.po ==========
+# Kirgyz translation of xed.
+# This file is distributed under the same license as the xed package.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER.
+# Stefano Karapetsas <stefano@karapetsas.com>, 2016
 
 
 
 ========== la.po ==========
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Free Software Foundation, Inc.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-
+# Latin translation of xed.
+# Copyright (C) 2021 Free Software Foundation, Inc.
+# Davide Novemila <Unknown>, 2021
 
 
 
 ========== lt.po ==========
-# translation of lt.po to Lithuanian
-# Lithuanian translation of xed
+# Lithuanian translation of xed.
 # Copyright (C) 2000-2006, 2007, 2008 Free Software Foundation, Inc.
-#
-#
 # Gediminas Paulauskas <menesis@chatsubo.lt>, 2000-2003.
 # Vaidotas Zemlys <mpiktas@delfi.lt>, 2003.
 # Žygimantas Beručka <zygis@gnome.org>, 2003-2006.
@@ -723,38 +665,30 @@
 
 
 
-
 ========== lv.po ==========
-# translation of lv.po to Latvian
+# Latvian translation of xed.
 # Copyright (C) 2006, 2007, 2009 Free Software Foundation, Inc.
-#
 # Raivis Dejus <orvils@gmail.com>, 2006, 2007, 2009.
 # Rūdolfs Mazurs <rudolfs.mazurs@gmail.com>, 2009, 2010.
 
 
 
-
 ========== mai.po ==========
-# translation of xed.master.mai.po to Hindi
+# Maithili translation of xed.
+# Copyright (C) 2006 The MATE Foundation
+# This file is distributed under the same license as the xed package.
 # BOSS GNU/Linux <bosslinux@cdac.in>, 2008.
 # Rajesh Ranjan <rranjan@redhat.com>, 2009.
 # Rajesh Ranjan <rajesh672@gmail.com>, 2009.
-# translation to xed to Maithili
-# Copyright (C) 2006 The MATE Foundation
-# This file is distributed under the same license as the PACKAGE package.
-
 
 
 
 ========== mg.po ==========
-# Malagasy translation of XED
+# Malagasy translation of xed.
 # Copyright (C) 2006 THE XED'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the XED package.
+# This file is distributed under the same license as the xed package.
 # Fanomezana Rajaonarisoa <rajfanhar@yahoo.fr>, 2006.
 # Thierry Randrianiriana <randrianiriana@gmail.com>, 2006.
-#
-#
-
 
 
 
@@ -763,17 +697,12 @@
 # Copyright (C) 2004 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
 # John C Barstow <jbowtie@amathaine.com>, 2004.
-#
-
 
 
 
 ========== mk.po ==========
-# translation of mk.po to Macedonian
-# translation of xed.HEAD.mk.po to
+# Macedonian translation of xed.
 # Copyright (C) 2002,2003, 2004, 2005, 2006, 2007, 2008 Free Software Foundation, Inc.
-#
-#
 # Igor Petreski <dierektor@pcinfo.com.mk>, 2002.
 # Arangel Angov <ufo@linux.net.mk>, 2003, 2004, 2006, 2008.
 # Ime Prezime <email@adresa.com>, 2003.
@@ -788,12 +717,10 @@
 
 
 
-
 ========== ml.po ==========
-# translation of xed.master.ml.po to Malayalam
+# Malayalam translation of xed.
 # This file is distributed under the same license as the xed package.
 # Copyright (C) 2007-2008 xed'S COPYRIGHT HOLDER.
-#
 # FSF-India <locale@gnu.org.in>, 2003.
 # Ani Peter <apeter@redhat.com>, 2006, 2007.
 # Santhosh Thottingal <santhosh00@gmail.com>, 2007.
@@ -802,23 +729,19 @@
 
 
 
-
 ========== mn.po ==========
-# translation of xed.HEAD.po to Mongolian
-# This file is distributed under the same license as the PACKAGE package.
+# Mongolian translation of xed.
+# This file is distributed under the same license as the xed package.
 # Copyright (C) 2003
 # Sanlig Badral <badral@users.sf.net>, 2003.
 # Sanlig Badral <Badral@openmn.org>, 2004.
-#
-
 
 
 
 ========== mr.po ==========
-# translation of mr.po to Marathi
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-#
+# Marathi translation of xed.
+# Copyright (C) 2006 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
 # Rahul Bhalerao <rbhalera@redhat.com>, 2006.
 # Rahul Bhalerao <b.rahul.pm@gmail.com>, 2006.
 # Sandeep Shedmake <sandeep.shedmake@gmail.com>, 2008, 2009.
@@ -828,24 +751,29 @@
 
 
 
-
 ========== ms.po ==========
+# Malay translation of xed.
+# Copyright (C) 2002 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
 # Xed Bahasa Melayu (ms)
 # Jika takut risiko, Jangan bicara tentang Perjuangan
 # Hasbullah Bin Pit (sebol) <sebol@ikhlas.com>, 2002
-#
 
+
+========== my.po ==========
+# Burmese translation of xed.
+# Copyright (C) 2002 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
+# Naungy <naungy007@gmail.com>,2016
 
 
 
 ========== nb.po ==========
-# Norwegian translation of xed (bokmål).
+# Norwegian translation of xed.
 # Copyright (C) 1998-2004, 2005 Free Software Foundation, Inc.
 # Kjartan Maraas <kmaraas@gnome.org>, 1998-2010.
 # Terance Edward Sola <terance@lyse.net>, 2005.
 # Sigurd Gartmann <sigurd-translate@brogar.org>, 2005.
-#
-
 
 
 
@@ -854,29 +782,22 @@
 # Copyright (C) 2009 xed's COPYRIGHT HOLDER
 # This file is distributed under the same license as the xed package.
 # Nils-Christoph Fiedler <fiedler@medienkompanie.de>, 2009.
-#
-
 
 
 
 ========== ne.po ==========
-# translation of xed.HEAD.ne.po to Nepali
-# Translation of xed.po to Nepali
-# This file is distributed under the same license as the PACKAGE package.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER.
-#
+# Nepali translation for xed.
+# This file is distributed under the same license as the xed package.
+# Copyright (C) 2003 THE PACKAGE'S COPYRIGHT HOLDER.
 # Pawan Chitrakar <pawan@nplinu.org>, 2003.
 # Ganesh Ghimire <gghimire@gmail.com>, 2005.
 # Narayan Kumar Magar <narayan@mpp.org.np>, 2007.
 
 
 
-
 ========== nl.po ==========
-# Dutch translation for xed
-#
+# Dutch translation for xed.
 # This file is distributed under the same license as the xed package.
-#
 # Dennis Smit <synap@area101.penguin.nl>, 2000.
 # Ludootje <ludootje@linux.be>, 2001.
 # Jan-Willem Harmanny <jwharmanny@hotmail.com>, 2002.
@@ -890,14 +811,11 @@
 # Rob van den Berg <linuxned@gmail.com>, 2010.
 # Kenneth Venken <kenneth.venken@gmail.com>, 2010.
 # Hannie Dumoleyn <lafeber-dumoleyn2@zonnet.nl>, 2010.
-#
-
 
 
 
 ========== nn.po ==========
-# translation of nn.po to Norwegian Nynorsk
-# Norwegian (nynorsk) translation of xed
+# Norwegian Nynorsk translation for xed.
 # Copyright (C) 2000 Gaute Hvoslef Kvalnes.
 # Gaute Hvoslef Kvalnes <ai98ghk@stud.hib.no>, 2000.
 # Kjartan Maraas  <kmaraas@gnome.org>, 2001.
@@ -906,36 +824,28 @@
 
 
 
-
 ========== oc.po ==========
-# Translation of oc.po to Occitan
 # Occitan translation of xed.
 # Copyright (C) 2007 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
-#
 # Yannig Marchegay (Kokoyaya) <yannig@marchegay.org>, 2007.
 
 
 
-
 ========== or.po ==========
-# translation of xed.mate-2-30.or.po to Oriya
-# translation of or.po to
-# Oriya translation of xed.HEAD.pot.
+# Oriya translation of xed.
 # This file is distributed under the same license as the xed package.
 # Copyright (C) 2004, 2006, 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
-#
 # Gora Mohanty <gora_mohanty@yahoo.co.in>, 2004.
 # Subhransu Behera <arya_subhransu@yahoo.co.in>, 2006, 2007.
 # Manoj Kumar Giri <mgiri@redhat.com>, 2008, 2009, 2010.
 
 
 
-
 ========== pa.po ==========
-# translation of xed.HEAD.po to Punjabi
-#
-#
+# Punjabi translation of xed.
+# This file is distributed under the same license as the xed package.
+# Copyright (C) 2004 THE PACKAGE'S COPYRIGHT HOLDER.
 # Amanpreet Singh Alam <amanliunx@netscapet.net>, 2004.
 # ASB <aalam@users.sf.net>, 2005, 2006, 2007.
 # Amanpreet Singh Alam <aalam@users.sf.net>, 2008.
@@ -943,35 +853,34 @@
 
 
 
-
 ========== pl.po ==========
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation of xed.
+# This file is distributed under the same license as the xed package.
+# Copyright (C) 2021 THE PACKAGE'S COPYRIGHT HOLDER.
+#
 # Aviary.pl
 # Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
 # pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
 # matepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-
+#
+# Paweł Pańczyk <pawelppanczyk@gmail.com>, 2021
 
 
 
 ========== ps.po ==========
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-
+# Pushto translation of xed.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
+# Stefano Karapetsas <stefano@karapetsas.com>, 2016
 
 
 
 ========== pt.po ==========
-# xed's Portuguese translation
-# Copyright © 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010 xed
+# Portuguese translation of xed.
+# Copyright (C) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010
 # Distributed under the same licence as the xed package
 # Duarte Loreto <happyguy_pt@hotmail.com>, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010.
-#
-
+# Hugo Carvalho <hugokarvalho@hotmail.com>, 2021
 
 
 
@@ -998,30 +907,25 @@
 # Fábio Nogueira <deb-user-ba@ubuntu.com>, 2008, 2009.
 # Carlos José Pereira <carlao2005@gmail.com>, 2009
 # Henrique P. Machado <hpmachado@gnome.org>, 2010.
-#
-#
-
+# Gilberto vagner <vagner.unix@gmail.com>
 
 
 
 ========== ro.po ==========
-# Romanian translation for xed
+# Romanian translation of xed.
 # Copyright (C) 2003-2008 Free Software Foundation, Inc.
 # Mugurel Tudor <mugurelu@mate.ro>, 2003, 2004.
 # Dan Damian <dand@ubuntu.ro>, 2005-2007.
 # Mișu Moldovan <dumol@mate.ro>, 2003, 2004, 2008.
 # Adi Roiban https://launchpad.net/~adiroiban, 2008, 2009
 # Lucian Adrian Grijincu <lucian.grijincu@gmail.com>, 2009, 2010
-
+# Dorian Baciu <Unknown>, 2020
 
 
 
 ========== ru.po ==========
-# translation of ru.po to Russian
-# translation of xed to Russian
+# Russian translation of xed.
 # Copyright (C) 1999-2003, 2004, 2005, 2006, 2007, 2008, 2010 Free Software Foundation, Inc.
-#
-#
 # Valek Filippov <frob@df.ru>, 2000-2002, 2003.
 # Sergey Panov <sipan@mit.edu>, 1999-2000.
 # Dmitry G. Mastrukov <dmitry@taurussoft.org>, 2002.
@@ -1032,12 +936,12 @@
 # Nickolay V. Shmyrev <nshmyrev@yandex.ru>, 2007.
 # Yuri Kozlov <kozlov.y@gmail.com>, 2008.
 # Alexander Saprykin <xelfium@gmail.com>, 2010.
-
+# Aleksey Kabanov <Unknown>, 2021
 
 
 
 ========== rw.po ==========
-# translation of xed to Kinyarwanda.
+# Kinyarwanda translation of xed.
 # Copyright (C) 2005 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
 # Steve Murphy <murf@e-tools.com>, 2005
@@ -1049,106 +953,81 @@
 # JEAN BAPTISTE NGENDAHAYO <ngenda_denis@yahoo.co.uk>, 2005.
 # Augustin KIBERWA  <akiberwa@yahoo.co.uk>, 2005.
 # Donatien NSENGIYUMVA <ndonatienuk@yahoo.co.uk>, 2005..
-#
-
 
 
 
 ========== si.po ==========
-# translation of si.po to Sinhala
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-#
+# Sinhala translation of xed.
+# Copyright (C) 2007 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
 # Danishka Navin <snavin@redhat.com>, 2007.
 
 
 
-
 ========== sk.po ==========
-# translation of xed.HEAD.po to Slovak
-# translation of sk.po to Slovak
-# Slovak translation of sk.po
-# xed sk.po
+# Slovak translation of xed.
 # Copyright (C) 2000-2002, 2003, 2004, 2005, 2009 Free Software Foundation, Inc.
 # Stanislav Visnovsky <visnovsky@nenya.ms.mff.cuni.cz>, 2000-2002,2003.
 # Stanislav Višňovský <visnovsky@nenya.ms.mff.cuni.cz>, 2002.
 # Stanislav Visnovsky <visnovsky@kde.org>, 2003, 2004.
 # Marcel Telka <marcel@telka.sk>, 2005, 2009.
-#
-
 
 
 
 ========== sl.po ==========
-# Slovenian translation for xed.
+# Slovenian translation of xed.
 # Copyright (C) 2005-2007 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
-#
 # Andraž Tori <andraz.tori1@guest.arnes.si>, 2000 - 2005.
 # Matic Žgur <mr.zgur@gmail.com>, 2006 - 2007.
 # Matej Urbančič <mateju@svn.gnome.org>, 2007 - 2010.
-#
-
 
 
 
 ========== sq.po ==========
-# Përkthimi i xed në shqip.
+# Albanian translation of xed.
 # Copyright (C) 2003-2007, 2008 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
 # Laurent Dhima <laurenti@alblinux.net>, 2003-2007, 2008.
 
 
 
-
 ========== sr.po ==========
-# Serbian translation of xed
+# Serbian translation of xed.
 # Courtesy of Prevod.org team (http://prevod.org/) -- 2003 - 2009.
-#
 # This file is distributed under the same license as the xed package.
-#
 # Maintainer: Горан Ракић <grakic@devbase.net>
 # Данило Шеган <danilo@prevod.org>, 2005.
 # Reviewed on 2005-09-03 by: Игор Несторовић <igor@prevod.org>
 # Translated on 2010-03-07 by: Бранко Кокановић <branko.kokanovic@gmail.com>
-#
-
 
 
 
 ========== sr@latin.po ==========
-# Serbian translation of xed
+# Serbian translation of xed.
 # Courtesy of Prevod.org team (http://prevod.org/) -- 2003 - 2009.
-#
 # This file is distributed under the same license as the xed package.
-#
 # Maintainer: Goran Rakić <grakic@devbase.net>
 # Danilo Šegan <danilo@prevod.org>, 2005.
 # Reviewed on 2005-09-03 by: Igor Nestorović <igor@prevod.org>
 # Translated on 2010-03-07 by: Branko Kokanović <branko.kokanovic@gmail.com>
-#
-
 
 
 
 ========== sv.po ==========
-# Swedish messages for xed. 
+# Swedish translation of xed.
 # Copyright (C) 1998-2010 Free Software Foundation, Inc.
 # Martin Wahlen <mva@sslug.dk>, 1998.
 # Martin Norbäck <d95mback@dtek.chalmers.se>, 1999, 2000.
 # Andreas Hyden <a.hyden@cyberpoint.se>, 2000.
 # Christian Rose <menthos@menthos.com>, 2000, 2001, 2002, 2003, 2004, 2005.
 # Daniel Nylander <po@danielnylander.se>, 2006, 2007, 2008, 2009, 2010.
-#
-
 
 
 
 ========== ta.po ==========
-# translation of xed.master.ta.po to Tamil
-# Tamil Translation of xed
+# Tamil Translation of xed.
 # Copyright (C) 2001 Dinesh Nadarajah
-#
 # Dinesh Nadarajah, 2001 <n_dinesh@yahoo.com>.
 # Dinesh Nadarajah, 2004 <dinesh_list@sbcglobal.net>.
 # Jayaradha N <jaya@pune.redhat.com>, 2004.
@@ -1160,19 +1039,20 @@
 
 
 
-
 ========== te.po ==========
-# translation of xed.master.te.po to Telugu
-# Telugu translation of xed
+# Telugu translation of xed.
 # Copyright (C) 2005 Free Software Foundation, Andhra Pradesh.
 # Copyright (C) 2007 Swecha Telugu Localisation Team <localisation@swecha.org>
 # This file is distributed under the same license as the xed package.
-#
-#
 # Prajasakti Localisation Team <localisation@prajasakti.com>, 2005.
 # Swecha Telugu Localisation Team <localisation@swecha.org>, 2007.
 # Krishna Babu K <kkrothap@redhat.com>, 2007, 2008, 2009.
 
+
+
+========== tg.po ==========
+# Tajik translation of xed.
+# This file is distributed under the same license as the xed package.
 
 
 
@@ -1180,7 +1060,6 @@
 # Thai translation of xed.
 # Copyright (C) 2004-2009 Free Software Foundation, Inc.
 # This file is distributed under the same license as the xed package.
-#
 # Supakorn Siddhichai <supakorn.siddhichai@nectec.or.th>, 2003, 2004.
 # Supranee Thirawatthanasuk <supranee@opentle.org>, 2004.
 # Chanchai Junlouchai <taz@opentle.org>, 2004.
@@ -1190,16 +1069,12 @@
 
 
 
-
 ========== tk.po ==========
-# Turkmen translation of xed
+# Turkmen translation of xed.
 # Copyright (C) 2004 Free Software Foundation
 # Copyright (C) 2004 Kakilik Project <kakilik.sourceforge.net>
 # This file is distributed under the terms of GNU General Public License (GPL)
 # Gurban Mühemmet Tewekgeli <gmtavakkoli@yahoo.com>, 2004.
-#
-#
-
 
 
 
@@ -1214,56 +1089,66 @@
 
 
 
-
 ========== uk.po ==========
-# xed.po for ukrainian language.
+# Ukrainian translations of xed.
 # Copyright (C) 1999,2000 Free Software Foundation, Inc.
 # Yuri Syrota <yuri@renome.rovno.ua>, 1999.
 # Maxim Dziumanenko <dziumanenko@gmail.com>, 2004-2008
 # Ivan Petruk <petruk.ivan@gmail.com>
-#
 # wanderlust <wanderlust@ukr.net>, 2009.
 
+
+
+========== ur.po ==========
+# Urdu translation of xed.
+# Copyright (C) 2016 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
+# Waqar Ahmed <waqar.17a@gmail.com>, 2016
 
 
 
 ========== vi.po ==========
 # Vietnamese translation for GEdit.
-# Copyright © 2009 MATE i18n Project for Vietnamese.
+# Copyright (C) 2009 MATE i18n Project for Vietnamese.
 # Nguyễn Thái Ngọc Duy <pclouds@gmail.com>, 2002-2004,2007.
 # Clytie Siddall <clytie@riverland.net.au>, 2005-2009.
-#
-
 
 
 
 ========== wa.po ==========
-# Translation into the walloon language.
+# Walloon translation of xed.
+# Copyright (C) 1999 Free Software Foundation, Inc.
 #
 # Si vos voloz donner on côp di spale pol ratournaedje di Mate (ou des
 # ôtes libes programes) sicrijhoz-mu a l' adresse emile
 # <srtxg@chanae.alphanet.ch>; nos avons co bråmint di l' ovraedje a fé.
 #
-# Copyright (C) 1999 Free Software Foundation, Inc.
 # Pablo Saratxaga <srtxg@chanae.alphanet.ch> 1999-2003
 # Pablo Saratxaga <pablo@walon.org>, 2003, 2004, 2005.
-#
-
 
 
 
 ========== xh.po ==========
-# Xhosa translations of xed
+# Xhosa translation of xed.
 # Copyright (C) 2005 Canonical Ltd.
 # This file is distributed under the same license as the xed package.
 # Translation by Canonical Ltd <translations@canonical.com> with thanks to
 # Translation World CC in South Africa, 2005.
-#
 
+
+
+========== zgh.po ============
+# Standard Moroccan Tamazight translation of xed.
+# Copyright (c) 2020 Rosetta Contributors and Canonical Ltd 2020
+# This file is distributed under the same license as the linuxmint package.
+# Hakim Oubouali <Unknown>, 2020
 
 
 
 ========== zh_CN.po ==========
+# Chinese (China) translation of xed.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the xed package.
 # Original by Dillion Chen <dillon.chen@turbolinux.com.cn>
 # Totally rewritten by Tom Mak <mhh@126.com>, 2001
 # Minor update by Wang Jian <lark@linux.net.cn>, 2001
@@ -1277,7 +1162,6 @@
 
 
 
-
 ========== zh_HK.po ==========
 # Chinese (Hong Kong) translation of xed.
 # Copyright (C) 2000-07 Free Software Foundation, Inc.
@@ -1286,9 +1170,6 @@
 # Anthony Tang <tkyanthony@yahoo.com.hk>, 2004.
 # Woodman Tuen <wmtuen@gmail.com>, 2005-2007.
 # Chao-Hsiung Liao <j_h_liau@yahoo.com.tw>, 2008
-#
-#
-
 
 
 
@@ -1300,9 +1181,3 @@
 # Anthony Tang <tkyanthony@yahoo.com.hk>, 2004.
 # Woodman Tuen <wmtuen@gmail.com>, 2005-2007.
 # Chao-Hsiung Liao <j_h_liau@yahoo.com.tw>, 2008
-#
-#
-
-
-
-


### PR DESCRIPTION
The content of po/fr_CA.po was not complete.  The missing
translations were added.

gnome-copyrights.txt was modified to indicate these modifications,
and maintain an identical format throughout.