### PR TITLE
Adding GUI setting for XED_SETTINGS_MAX_RECENTS

### DIFF
--- a/xed/resources/ui/xed-preferences-dialog.ui
+++ b/xed/resources/ui/xed-preferences-dialog.ui
@@ -949,6 +949,12 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment4">
+    <property name="upper">100</property>
+    <property name="lower">0</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkBox" id="save_page">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -1154,6 +1160,77 @@
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label24">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">History</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="scale" value="1.1000000000000001"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box201">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">32</property>
+                    <property name="margin_right">32</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                          <object class="GtkBox" id="box231">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="label_max_recent">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Maximum recent files</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="max_recent_spin">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="adjustment">adjustment4</property>
+                                <property name="climb_rate">1</property>
+                                <property name="numeric">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="pack_type">end</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>

--- a/xed/xed-preferences-dialog.c
+++ b/xed/xed-preferences-dialog.c
@@ -81,6 +81,7 @@ struct _XedPreferencesDialog
     GtkWidget *auto_save_spin;
     GtkWidget *auto_save_revealer;
     GtkWidget *ensure_newline_switch;
+    GtkWidget *max_recent_spin;
 
     /* Font */
     GtkWidget *fixed_width_font_label;
@@ -199,6 +200,7 @@ xed_preferences_dialog_class_init (XedPreferencesDialogClass *klass)
     gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, auto_save_spin);
     gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, auto_save_revealer);
     gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, ensure_newline_switch);
+    gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, max_recent_spin);
 
     /* Theme page widgets */
     gtk_widget_class_bind_template_child (widget_class, XedPreferencesDialog, prefer_dark_theme_switch);
@@ -469,6 +471,12 @@ setup_save_page (XedPreferencesDialog *dlg)
                      XED_SETTINGS_ENSURE_TRAILING_NEWLINE,
                      dlg->ensure_newline_switch,
                      "active",
+                     G_SETTINGS_BIND_GET | G_SETTINGS_BIND_SET);
+
+    g_settings_bind (dlg->ui_settings,
+                     XED_SETTINGS_MAX_RECENTS,
+                     dlg->max_recent_spin,
+                     "value",
                      G_SETTINGS_BIND_GET | G_SETTINGS_BIND_SET);
 
     xapp_preferences_window_add_page (XAPP_PREFERENCES_WINDOW (dlg), dlg->save_page, "save", _("Save"));


### PR DESCRIPTION
I added a GUI setting for changing the number of recent files. See #371
It does not update the list directly upon changing as the method `on_max_recents_changed` in `xed-settings.c` is not implemented yet.
Also, should this actually update this system setting? Or should it be application dependent?