### PR TITLE
Save correct window size on exit

### DIFF
--- a/xed/xed-window.c
+++ b/xed/xed-window.c
@@ -182,12 +182,7 @@ save_window_state (GtkWidget *widget)
     if ((window->priv->window_state &
         (GDK_WINDOW_STATE_MAXIMIZED | GDK_WINDOW_STATE_FULLSCREEN)) == 0)
     {
-        GtkAllocation allocation;
-
-        gtk_widget_get_allocation (widget, &allocation);
-
-        window->priv->width = allocation.width;
-        window->priv->height = allocation.height;
+        gtk_window_get_size(GTK_WINDOW(widget), &window->priv->width, &window->priv->height);
 
         g_settings_set (window->priv->window_settings, XED_SETTINGS_WINDOW_SIZE,
                         "(ii)", window->priv->width, window->priv->height);


### PR DESCRIPTION
Problem:
Current behavior may result in incorrect window dimensions being saved (as `gtk_widget_get_allocation` doesn't account for window decorations, etc.).

Solution:
Use `gtk_window_get_size` (the recommended GTK function to call for storing window dimensions) to get current dimensions to be saved.