### PR TITLE
meson.build: use gzip -k instead of --keep

### DIFF
--- a/plugins/taglist/meson.build
+++ b/plugins/taglist/meson.build
@@ -56,7 +56,7 @@ foreach tagtype : taglist_in_files
         '@0@gztags'.format(tagtype.format('')),
         input: taglist_xml,
         output: tagtype.format('.gz'),
-        command: ['gzip', '-9', '-n', '--keep', '-f', '@INPUT@'],
+        command: ['gzip', '-9', '-n', '-k', '-f', '@INPUT@'],
         install: true,
         install_dir: join_paths(pluginsdatadir, 'taglist')
     )


### PR DESCRIPTION
the busybox version of gzip does not implement --keep. the other implementations (GNU, BSD), do.
all implement -k, so -k has the highest compatibility.