### PR TITLE
Update xed-metadata-manager.c - Fix missing include for newer libxml

### DIFF
--- a/xed/xed-metadata-manager.c
+++ b/xed/xed-metadata-manager.c
@@ -21,6 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include <libxml/globals.h>
 #include <libxml/xmlreader.h>
 #include "xed-metadata-manager.h"
 #include "xed-debug.h"


### PR DESCRIPTION
Fix missing include for newer libxml