### PR TITLE
added shortcut to duplicate selection

### DIFF
--- a/xed/resources/ui/xed-shortcuts.ui
+++ b/xed/resources/ui/xed-shortcuts.ui
@@ -7,7 +7,7 @@
       <object class="GtkShortcutsSection">
         <property name="visible">1</property>
         <property name="section-name">shortcuts</property>
-        <property name="max-height">15</property>
+        <property name="max-height">16</property>
         <child>
           <object class="GtkShortcutsGroup">
             <property name="visible">1</property>
@@ -268,6 +268,13 @@
                 <property name="visible">1</property>
                 <property name="accelerator">&lt;ctrl&gt;D</property>
                 <property name="title" translatable="yes">Delete current line</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
+                <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;D</property>
+                <property name="title" translatable="yes">Duplicate current line</property>
               </object>
             </child>
             <child>

--- a/xed/resources/ui/xed-ui.xml
+++ b/xed/resources/ui/xed-ui.xml
@@ -38,6 +38,7 @@
       <menuitem name="EditCopyMenu" action="EditCopy"/>
       <menuitem name="EditPasteMenu" action="EditPaste"/>
       <menuitem name="EditDeleteMenu" action="EditDelete"/>
+      <menuitem name="EditDuplicateMenu" action="EditDuplicate"/>
       <placeholder name="EditOps_1" />
       <separator/>
       <placeholder name="EditOps_2" />

--- a/xed/xed-commands-edit.c
+++ b/xed/xed-commands-edit.c
@@ -146,6 +146,22 @@ _xed_cmd_edit_delete (GtkAction   *action,
 }
 
 void
+_xed_cmd_edit_duplicate (GtkAction   *action,
+		     XedWindow *window)
+{
+	XedView *active_view;
+
+	xed_debug (DEBUG_COMMANDS);
+
+	active_view = xed_window_get_active_view (window);
+	g_return_if_fail (active_view);
+
+	xed_view_duplicate (active_view);
+
+	gtk_widget_grab_focus (GTK_WIDGET (active_view));
+}
+
+void
 _xed_cmd_edit_select_all (GtkAction   *action,
 			   XedWindow *window)
 {

--- a/xed/xed-commands.h
+++ b/xed/xed-commands.h
@@ -40,6 +40,7 @@ void _xed_cmd_edit_cut (GtkAction *action, XedWindow *window);
 void _xed_cmd_edit_copy (GtkAction *action, XedWindow *window);
 void _xed_cmd_edit_paste (GtkAction *action, XedWindow *window);
 void _xed_cmd_edit_delete (GtkAction *action, XedWindow *window);
+void _xed_cmd_edit_duplicate (GtkAction *action, XedWindow *window);
 void _xed_cmd_edit_select_all (GtkAction *action, XedWindow *window);
 void _xed_cmd_edit_preferences (GtkAction *action, XedWindow *window);
 void _xed_cmd_edit_toggle_comment (GtkAction *action, XedWindow *window);

--- a/xed/xed-ui.h
+++ b/xed/xed-ui.h
@@ -102,6 +102,8 @@ static const GtkActionEntry xed_menu_entries[] =
 	  N_("Paste the clipboard"), G_CALLBACK (_xed_cmd_edit_paste) },
 	{ "EditDelete", "edit-delete-symbolic", N_("_Delete"), NULL,
 	  N_("Delete the selected text"), G_CALLBACK (_xed_cmd_edit_delete) },
+	{ "EditDuplicate", "edit-duplicate-symbolic", N_("_Duplicate"),	"<control><shift>D",
+	  N_("Duplicate the selected text"), G_CALLBACK (_xed_cmd_edit_duplicate) },
 	{ "EditSelectAll", "edit-select-all-symbolic", N_("Select _All"), "<control>A",
 	  N_("Select the entire document"), G_CALLBACK (_xed_cmd_edit_select_all) },
     { "EditToggleComment", NULL, N_("_Toggle Comment"), "<control>slash",

--- a/xed/xed-view.c
+++ b/xed/xed-view.c
@@ -755,6 +755,45 @@ xed_view_delete_selection (XedView *view)
 }
 
 /**
+ * xed_view_duplicate:
+ * @view: a #XedView
+ *
+ * Duplicates the text currently selected in the #GtkTextBuffer
+ * or duplicates the current line if nothing is selected
+ **/
+void
+xed_view_duplicate (XedView *view)
+{
+    GtkTextIter start;
+    GtkTextIter end;
+    GtkTextBuffer *buffer = NULL;
+    gchar *text;
+    size_t length;
+
+    xed_debug (DEBUG_VIEW);
+
+    g_return_if_fail (XED_IS_VIEW (view));
+
+    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW(view));
+    g_return_if_fail (buffer != NULL);
+
+    if (!gtk_text_buffer_get_selection_bounds (buffer, &start, &end))
+    {
+        gtk_text_iter_set_line_index (&start, 0);
+        gtk_text_iter_forward_to_line_end (&end);
+    }
+
+    gtk_text_iter_order (&start, &end);
+    text = gtk_text_buffer_get_text (buffer, &start, &end, TRUE);
+
+    if ((length = strlen(text)) > 0)
+    {
+        gtk_text_buffer_insert (buffer, &end, "\n", 1);
+        gtk_text_buffer_insert (buffer, &end, text, length);
+    }
+}
+
+/**
  * xed_view_select_all:
  * @view: a #XedView
  *

--- a/xed/xed-view.c
+++ b/xed/xed-view.c
@@ -791,6 +791,8 @@ xed_view_duplicate (XedView *view)
         gtk_text_buffer_insert (buffer, &end, "\n", 1);
         gtk_text_buffer_insert (buffer, &end, text, length);
     }
+
+    g_free (text);
 }
 
 /**

--- a/xed/xed-view.h
+++ b/xed/xed-view.h
@@ -58,6 +58,7 @@ void       xed_view_cut_clipboard (XedView *view);
 void       xed_view_copy_clipboard (XedView *view);
 void       xed_view_paste_clipboard (XedView *view);
 void       xed_view_delete_selection (XedView *view);
+void       xed_view_duplicate (XedView *view);
 void       xed_view_select_all (XedView *view);
 void       xed_view_scroll_to_cursor (XedView *view);
 void       xed_view_set_font (XedView *view, gboolean def, const gchar *font_name);


### PR DESCRIPTION
By doing CTRL + SHIFT + D the user can duplicate the selection.

![Screenshot from 2023-12-14 08-07-44](https://github.com/linuxmint/xed/assets/138604946/d9d604ed-e815-4b2f-be51-06c776d7e484)

Correcting issue #610

If some text is selected, the selection will be duplicated below.
If no text is selected, the line will be duplicated if it has more than 0 characters.