### PR TITLE
removed trailing space char in custom date time

### DIFF
--- a/plugins/time/xed-time-plugin.c
+++ b/plugins/time/xed-time-plugin.c
@@ -712,7 +712,6 @@ real_insert_time (GtkTextBuffer *buffer,
     gtk_text_buffer_begin_user_action (buffer);
 
     gtk_text_buffer_insert_at_cursor (buffer, the_time, -1);
-    gtk_text_buffer_insert_at_cursor (buffer, " ", -1);
 
     gtk_text_buffer_end_user_action (buffer);
 }


### PR DESCRIPTION
Removed line that added a space character after custom date and time insert.

Fixing issue #614

When the user inserts a date and time with a custom format, a trailing space character is added.
The line doing that was removed.