### PR TITLE
added shortcut to toggle overview map (#623)

### DIFF
--- a/xed/resources/ui/xed-shortcuts.ui
+++ b/xed/resources/ui/xed-shortcuts.ui
@@ -105,6 +105,13 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">1</property>
+                <property name="accelerator">F7</property>
+                <property name="title" translatable="yes">Show overview map</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">1</property>
                 <property name="accelerator">F11</property>
                 <property name="title" translatable="yes">Fullscreen on / off</property>
               </object>

--- a/xed/xed-ui.h
+++ b/xed/xed-ui.h
@@ -172,7 +172,7 @@ static const GtkToggleActionEntry xed_always_sensitive_toggle_menu_entries[] =
     { "ViewWordWrap", NULL, N_("_Word wrap"), "<control>R",
       N_("Set word wrap for the current document"),
       G_CALLBACK (_xed_cmd_view_toggle_word_wrap), FALSE },
-    { "ViewOverviewMap", NULL, N_("_Overview Map"), NULL,
+    { "ViewOverviewMap", NULL, N_("_Overview Map"), "F7",
       N_("Show or hide the overview map for the current view"),
       G_CALLBACK (_xed_cmd_view_toggle_overview_map), FALSE }
 };


### PR DESCRIPTION
To keep with the consistency of using the function keys for toggling windows I mapped F7 to toggle the overview map.
![image](https://github.com/linuxmint/xed/assets/103229880/55bec55f-159b-492c-b3e5-c812d9dbfbe4)

To implement the feature request from issue #623 

Upon using the shortcut the overview map will be toggled similar to how the side and bottom panels work presently.