### PR TITLE
added method to cancel file loading before closing tab (#637)

### DIFF
--- a/xed/xed-notebook.c
+++ b/xed/xed-notebook.c
@@ -902,6 +902,12 @@ static void
 remove_tab (XedTab      *tab,
             XedNotebook *nb)
 {
+    /* First cancel any loading */
+    if (xed_tab_get_state (tab) == XED_TAB_STATE_LOADING)
+    {
+        _xed_tab_cancel_load (tab);
+    }
+
     gint position;
 
     position = gtk_notebook_page_num (GTK_NOTEBOOK (nb), GTK_WIDGET (tab));

--- a/xed/xed-tab.c
+++ b/xed/xed-tab.c
@@ -1995,6 +1995,15 @@ _xed_tab_load (XedTab                  *tab,
 }
 
 void
+_xed_tab_cancel_load (XedTab *tab)
+{
+    g_return_if_fail (XED_IS_PROGRESS_INFO_BAR (tab->priv->info_bar));
+    g_return_if_fail (G_IS_CANCELLABLE (tab->priv->cancellable));
+
+    g_cancellable_cancel (tab->priv->cancellable);
+}
+
+void
 _xed_tab_load_stream (XedTab                  *tab,
                       GInputStream            *stream,
                       const GtkSourceEncoding *encoding,

--- a/xed/xed-tab.h
+++ b/xed/xed-tab.h
@@ -129,6 +129,8 @@ void _xed_tab_load (XedTab                  *tab,
                     gint                     line_pos,
                     gboolean                 create);
 
+void _xed_tab_cancel_load (XedTab *tab);
+
 void _xed_tab_load_stream     (XedTab                  *tab,
                                GInputStream            *location,
                                const GtkSourceEncoding *encoding,


### PR DESCRIPTION
In order to address the issue of the xed program continuing to use computer resources while closing a tab/the application while one or more tabs are in the loading state a new method _xed_tab_cancel_load was created and is called in xed-notebook.

Fixes issue #637 

See video below to show how the new functionality is reflected in the activity monitor:
https://github.com/linuxmint/xed/assets/103229880/a3c0f921-b520-4a20-8005-47dd546c66dd

