### PR TITLE
Duplicate only current line when cursor is at the end of the line

### DIFF
--- a/xed/xed-view.c
+++ b/xed/xed-view.c
@@ -781,6 +781,16 @@ xed_view_duplicate (XedView *view)
     {
         gtk_text_iter_set_line_index (&start, 0);
         gtk_text_iter_forward_to_line_end (&end);
+
+        if (gtk_text_buffer_get_line_count (buffer) > 1)
+        {
+            gtk_text_iter_assign (&end, &start);
+            while (gtk_text_iter_get_char (&end) != '\n' &&
+                    !gtk_text_iter_is_end (&end))
+            {
+                gtk_text_iter_forward_char (&end);
+            }
+        }
     }
 
     gtk_text_iter_order (&start, &end);


### PR DESCRIPTION
This fixes issue #643. When cursor is at the end of the line, old version would duplicate two lines: The line where the cursor is, and the line following it. This happened because the buffer that is being copied would include both lines and the newline separating them. This fix checks if there are multiple lines in the current buffer, and if so, moves buffers end iterator to the newline character, so that only the line where cursor is located is duplicated.